### PR TITLE
[New Rule] The use of literal logical operators MUST be avoided #23.

### DIFF
--- a/Magento/ruleset.xml
+++ b/Magento/ruleset.xml
@@ -200,6 +200,10 @@
         <severity>6</severity>
         <type>warning</type>
     </rule>
+    <rule ref="Squiz.Operators.ValidLogicalOperators">
+        <severity>6</severity>
+        <type>warning</type>
+    </rule>
     <rule ref="Squiz.Functions.GlobalFunction">
         <severity>8</severity>
     </rule>


### PR DESCRIPTION
Added new rule: Squiz.Operators.ValidLogicalOperators.

Solution for magento/magento-coding-standard#23: [New Rule] The use of literal logical operators MUST be avoided