### PR TITLE
Changed the severity of ValidLogicalOperators rule

### DIFF
--- a/Magento/ruleset.xml
+++ b/Magento/ruleset.xml
@@ -223,6 +223,10 @@
         <severity>7</severity>
         <type>warning</type>
     </rule>
+    <rule ref="Squiz.Operators.ValidLogicalOperators">
+        <severity>7</severity>
+        <type>warning</type>
+    </rule>
     <rule ref="Squiz.PHP.GlobalKeyword">
         <severity>7</severity>
         <type>warning</type>
@@ -397,10 +401,6 @@
         <type>warning</type>
     </rule>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing">
-        <severity>6</severity>
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Operators.ValidLogicalOperators">
         <severity>6</severity>
         <type>warning</type>
     </rule>


### PR DESCRIPTION
Changed the severity of ValidLogicalOperators (Ensures logical operators `and` and `or` are not used.) because it's about `General code issue.` not `Code style issue (PSR2).` Reference: [wiki](https://github.com/magento/magento-coding-standard/wiki/Magento-Marketplace-Extensions-Verification).