### PR TITLE
Move LineLength from ruleset to sniff (fixes #36)

### DIFF
--- a/Magento/Sniffs/Files/LineLengthSniff.php
+++ b/Magento/Sniffs/Files/LineLengthSniff.php
@@ -22,6 +22,16 @@ class LineLengthSniff extends FilesLineLengthSniff
     /**
      * @inheritdoc
      */
+    public $lineLimit = 120;
+
+    /**
+     * @inheritdoc
+     */
+    public $absoluteLineLimit = 120;
+
+    /**
+     * @inheritdoc
+     */
     protected function checkLineLength($phpcsFile, $stackPtr, $lineContent)
     {
         $previousLineRegexp = '~__\($|\bPhrase\($~';

--- a/Magento/Tests/Files/LineLengthUnitTest.inc
+++ b/Magento/Tests/Files/LineLengthUnitTest.inc
@@ -1,0 +1,16 @@
+<?php
+
+// allowed
+$shortString = 'This is a short line';
+
+// triggers an error
+$tooLongString = 'This is a pretty long line. The code sniffer will report an error if a single line exceeds the maximum character count. You have need to insert a line break to avoid this error.';
+
+// allowed
+$longStringBrokenUp = 'This is a pretty long line. The code sniffer would report an error if this was written as a ' .
+                      'single line. You have to insert a line break to avoid this error.';
+
+// allowed by Magento Standard (Generic ruleset would trigger warning / error)
+$test = '012344567890123445678901234456789012344567890123445678901234456789';
+$test1 = '01234456789012344567890123445678901234456789012344567890123445678901234456789';
+$test2 = '012344567890123445678901234456789012344567890123445678901234456789012344567890123445678901234456789';

--- a/Magento/Tests/Files/LineLengthUnitTest.php
+++ b/Magento/Tests/Files/LineLengthUnitTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Tests\Files;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+/**
+ * Class LineLengthUnitTest
+ */
+class LineLengthUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [
+            7 => 1
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/Magento/ruleset.xml
+++ b/Magento/ruleset.xml
@@ -118,10 +118,6 @@
         <type>warning</type>
     </rule>
     <rule ref="Magento.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="120"/>
-            <property name="absoluteLineLimit" value="120"/>
-        </properties>
         <severity>8</severity>
         <type>warning</type>
     </rule>


### PR DESCRIPTION
As suggested in https://github.com/magento/magento-coding-standard/issues/36#issuecomment-467913612, I moved the property declaration from the ruleset to the sniff itself.

I added an unit test but #6 should stay open as not all scenarios are covered yet.