### PR TITLE
XssTemplateSniff does not detect some use cases

### DIFF
--- a/Magento2/Sniffs/Security/XssTemplateSniff.php
+++ b/Magento2/Sniffs/Security/XssTemplateSniff.php
@@ -151,6 +151,10 @@ class XssTemplateSniff implements Sniff
             $startOfStatement = $this->file->findPrevious(T_OPEN_TAG, $stackPtr);
             return $this->file->findPrevious(T_COMMENT, $stackPtr, $startOfStatement);
         }
+        if ($this->tokens[$stackPtr]['code'] === T_OPEN_TAG_WITH_ECHO) {
+            $endOfStatement = $this->file->findNext(T_CLOSE_TAG, $stackPtr);
+            return $this->file->findNext(T_COMMENT, $stackPtr, $endOfStatement);
+        }
         return false;
     }
 

--- a/Magento2/Tests/Security/XssTemplateUnitTest.inc
+++ b/Magento2/Tests/Security/XssTemplateUnitTest.inc
@@ -1,5 +1,5 @@
 <!--unsafe-->
-<?php /* @noEscape */ echo $code; ?>
+
 <?php $block->getSomeData(); echo $block->getSomeData(); /* @escapeNotVerified */ echo $block->getSomeData();?>
 <?=  $block->getTitle();?>
 <?php echo $object->getSomeMethod($block->getHtmlId());?>
@@ -56,3 +56,4 @@ echo $var;
 <?php echo $block->escapeJs($js); ?>
 <?php echo $block->escapeCss($css); ?>
 <?php echo $block->getJsLayout($jsLayout); ?>
+<?= /* @noEscape */ json_encode($config) ?>

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -60,6 +60,7 @@
         <severity>10</severity>
         <type>error</type>
         <exclude-pattern>*/lib/*</exclude-pattern>
+        <exclude-pattern>*/Test/*</exclude-pattern>
     </rule>
     <rule ref="Magento2.Strings.ExecutableRegEx">
         <severity>10</severity>
@@ -97,6 +98,7 @@
         <severity>9</severity>
         <type>warning</type>
         <exclude-pattern>*/lib/*</exclude-pattern>
+        <exclude-pattern>*/Test/*</exclude-pattern>
     </rule>
     <rule ref="Magento2.Security.XssTemplate">
         <include-pattern>*.phtml</include-pattern>
@@ -252,6 +254,7 @@
     <rule ref="Squiz.PHP.GlobalKeyword">
         <severity>7</severity>
         <type>warning</type>
+        <exclude-pattern>*/Test/*</exclude-pattern>
     </rule>
     <rule ref="Squiz.Scope.MemberVarScope">
         <severity>7</severity>


### PR DESCRIPTION
- resolved magento/magento-coding-standard#65;
- added more exclude for `*/Test/*` folders.
