### PR TITLE
Made InsecureFunctionSniff in line with UnsecureFunctionsUsageTest

### DIFF
--- a/Magento2/Sniffs/Security/InsecureFunctionSniff.php
+++ b/Magento2/Sniffs/Security/InsecureFunctionSniff.php
@@ -33,9 +33,11 @@ class InsecureFunctionSniff extends ForbiddenFunctionsSniff
         'pcntl_exec' => null,
         'popen' => null,
         'proc_open' => null,
-        'serialize' => 'json_encode',
+        'serialize' => '\Magento\Framework\Serialize\SerializerInterface::serialize',
         'shell_exec' => null,
         'system' => null,
-        'unserialize' => 'json_decode',
+        'unserialize' => '\Magento\Framework\Serialize\SerializerInterface::unserialize',
+        'srand' => null,
+        'mt_srand'=> null,
     ];
 }

--- a/Magento2/Tests/Security/InsecureFunctionUnitTest.inc
+++ b/Magento2/Tests/Security/InsecureFunctionUnitTest.inc
@@ -23,3 +23,7 @@ proc_open('echo 1;');
 create_function('args', 'code');
 
 pcntl_exec('path/goes/here');
+
+srand();
+
+mt_srand();

--- a/Magento2/Tests/Security/InsecureFunctionUnitTest.php
+++ b/Magento2/Tests/Security/InsecureFunctionUnitTest.php
@@ -38,6 +38,8 @@ class InsecureFunctionUnitTest extends AbstractSniffUnitTest
             21 => 1,
             23 => 1,
             25 => 1,
+            27 => 1,
+            29 => 1,
         ];
     }
 }


### PR DESCRIPTION
Added `srand` and `mt_srand` to `InsecureFunctionSniff` to cover [UnsecureFunctionsUsageTest cases](https://github.com/magento/magento2/blob/2.3-develop/dev/tests/static/testsuite/Magento/Test/Legacy/_files/security/unsecure_php_functions.php).