### PR TITLE
Updated README.md regarding adding standards only in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ Due to security, when installed this way the Magento standard for phpcs cannot b
 You can achieve this by adding the following to your project's `composer.json`:
 ````
 "scripts": {
-    "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/",
-    "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/"
+    "post-install-cmd": [
+      "[ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/"
+    ],
+    "post-update-cmd": [
+      "[ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/"
+    ]
 }
 ````
 


### PR DESCRIPTION
The post-(install|update)-cmd should be only executed when we are in dev mode of composer. There is an environment variable definded ($COMPOSER_DEV_MODE) for this.