### PR TITLE
#86: Fix AbstractApiSniff for classes without comment

### DIFF
--- a/Magento2/Sniffs/Classes/AbstractApiSniff.php
+++ b/Magento2/Sniffs/Classes/AbstractApiSniff.php
@@ -48,6 +48,9 @@ class AbstractApiSniff implements Sniff
         }
 
         $commentStartPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1, 0);
+        if ($commentStartPtr === false) {
+            return;
+        }
         $commentCloserPtr = $tokens[$commentStartPtr]['comment_closer'];
 
         for ($i = $commentStartPtr; $i <= $commentCloserPtr; $i++) {

--- a/Magento2/Tests/Classes/AbstractApiUnitTest.1.inc
+++ b/Magento2/Tests/Classes/AbstractApiUnitTest.1.inc
@@ -28,7 +28,6 @@ class FooBar implements FooInterface
 
 }
 
-
 /**
  * Class Bar
  */

--- a/Magento2/Tests/Classes/AbstractApiUnitTest.2.inc
+++ b/Magento2/Tests/Classes/AbstractApiUnitTest.2.inc
@@ -1,0 +1,6 @@
+<?php
+
+abstract class FooNoComment implements FooInterface
+{
+
+}

--- a/Magento2/Tests/Classes/AbstractApiUnitTest.php
+++ b/Magento2/Tests/Classes/AbstractApiUnitTest.php
@@ -23,11 +23,17 @@ class AbstractApiUnitTest extends AbstractSniffUnitTest
     /**
      * @inheritdoc
      */
-    public function getWarningList()
+    public function getWarningList($testFile = '')
     {
-        return [
-            14 => 1,
-            23 => 1
-        ];
+        if ($testFile === 'AbstractApiUnitTest.1.inc') {
+            return [
+                14 => 1,
+                23 => 1
+            ];
+        }
+
+        return [];
+
+
     }
 }

--- a/Magento2/Tests/Classes/AbstractApiUnitTest.php
+++ b/Magento2/Tests/Classes/AbstractApiUnitTest.php
@@ -33,7 +33,5 @@ class AbstractApiUnitTest extends AbstractSniffUnitTest
         }
 
         return [];
-
-
     }
 }


### PR DESCRIPTION
The sniff doesn't work correctly when there is no comment in the class to test. Therefore, `$commentStartPtr` is `false` and the array lookup fails.

Note: the sniff in its current form fails if there are multiple abstract classes defined in one file and one of the classes doesn't have a comment. That happens because we search for the previous comment open tag, regardless of if the tag belongs to the current class we are looking at or to a previous one.

To fix this would be out of scope for #86, though.