### PR TITLE
Add note to check sniffer code by coding standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ You can verify your code by running
 $ vendor/bin/phpunit
 ```
 
+Also, verify that the sniffer code itself is written according to the Magento Coding Standard:
+```
+$ vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php
+```
+
 ## License
 Each Magento source file included in this distribution is licensed under OSL-3.0 license.
 


### PR DESCRIPTION
The readme tells devs working on the Magento Coding Standard to verify their work by running the unit tests.

In addition, Travis checks if the sniffs themselves follow the Coding Standard - so devs should do this too for a quicker feedback loop.