### PR TITLE
Removed class exists checks and added exclude patterns

### DIFF
--- a/Magento2/Sniffs/PHP/LiteralNamespacesSniff.php
+++ b/Magento2/Sniffs/PHP/LiteralNamespacesSniff.php
@@ -52,28 +52,12 @@ class LiteralNamespacesSniff implements Sniff
             $content = preg_replace('|\\\{2,}|', '\\', $content);
         }
 
-        if (preg_match($this->literalNamespacePattern, $content) === 1 && $this->classExists($content)) {
+        if (preg_match($this->literalNamespacePattern, $content) === 1) {
             $sourceFile->addWarning(
                 "Use ::class notation instead.",
                 $stackPtr,
                 'LiteralClassUsage'
             );
         }
-    }
-
-    /**
-     * Checks if class or interface exists.
-     *
-     * ToDo: get rig of this check https://github.com/magento/magento-coding-standard/issues/9
-     *
-     * @param string $className
-     * @return bool
-     */
-    private function classExists($className)
-    {
-        if (!isset($this->classNames[$className])) {
-            $this->classNames[$className] = class_exists($className) || interface_exists($className);
-        }
-        return $this->classNames[$className];
     }
 }

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -245,6 +245,10 @@
     <rule ref="Magento2.PHP.LiteralNamespaces">
         <severity>7</severity>
         <type>warning</type>
+        <exclude-pattern>*/_files/*</exclude-pattern>
+        <exclude-pattern>*/Fixtures/*</exclude-pattern>
+        <exclude-pattern>*/Test/*</exclude-pattern>
+        <exclude-pattern>*Test.php</exclude-pattern>
     </rule>
     <rule ref="Magento2.PHP.Var">
         <severity>7</severity>


### PR DESCRIPTION
As discussed on https://github.com/magento/magento-coding-standard/issues/9 removed ```class_exists``` and ```interface_exists``` on LiteralNamespacesSniff.

Added exclude patterns.