### PR TITLE
REPO-209: [EQP] Increase the severity level to 10 for insecure functions

### DIFF
--- a/Magento2/Sniffs/Security/InsecureFunctionSniff.php
+++ b/Magento2/Sniffs/Security/InsecureFunctionSniff.php
@@ -13,13 +13,6 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 class InsecureFunctionSniff extends ForbiddenFunctionsSniff
 {
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var boolean
-     */
-    public $error = false;
-
-    /**
      * List of patterns for forbidden functions.
      *
      * @var array
@@ -38,7 +31,7 @@ class InsecureFunctionSniff extends ForbiddenFunctionsSniff
         'system' => null,
         'unserialize' => '\Magento\Framework\Serialize\SerializerInterface::unserialize',
         'srand' => null,
-        'mt_srand'=> null,
+        'mt_srand' => null,
         'mt_rand' => 'random_int',
     ];
 }

--- a/Magento2/Tests/Security/InsecureFunctionUnitTest.php
+++ b/Magento2/Tests/Security/InsecureFunctionUnitTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento2\Tests\Security;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
@@ -16,14 +17,6 @@ class InsecureFunctionUnitTest extends AbstractSniffUnitTest
      * @inheritdoc
      */
     public function getErrorList()
-    {
-        return [];
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getWarningList()
     {
         return [
             3 => 1,
@@ -42,5 +35,13 @@ class InsecureFunctionUnitTest extends AbstractSniffUnitTest
             29 => 1,
             31 => 1,
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [];
     }
 }

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -65,6 +65,10 @@
         <exclude-pattern>*/Test/*</exclude-pattern>
         <exclude-pattern>*Test.php</exclude-pattern>
     </rule>
+    <rule ref="Magento2.Security.InsecureFunction">
+        <severity>10</severity>
+        <type>error</type>
+    </rule>
     <rule ref="Magento2.Security.LanguageConstruct">
         <severity>10</severity>
         <type>error</type>
@@ -101,10 +105,6 @@
 
     <!-- Severity 9 warnings: Possible security and issues that may cause bugs. -->
     <rule ref="Generic.Files.ByteOrderMark">
-        <severity>9</severity>
-        <type>warning</type>
-    </rule>
-    <rule ref="Magento2.Security.InsecureFunction">
         <severity>9</severity>
         <type>warning</type>
     </rule>


### PR DESCRIPTION
```php
public $forbiddenFunctions = [
        'assert' => null,
        'create_function' => null,
        'exec' => null,
        'md5' => 'improved hash functions (SHA-256, SHA-512 etc.)',
        'passthru' => null,
        'pcntl_exec' => null,
        'popen' => null,
        'proc_open' => null,
        'serialize' => '\Magento\Framework\Serialize\SerializerInterface::serialize',
        'shell_exec' => null,
        'system' => null,
        'unserialize' => '\Magento\Framework\Serialize\SerializerInterface::unserialize',
        'srand' => null,
        'mt_srand' => null,
        'mt_rand' => 'random_int',
    ];
```
Those functions are forbidden in Magento and its use will cause extension rejection on Marketplace.