### PR TITLE
Removed Squiz.Commenting.ClassComment since it does not cover all Magento cases

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -493,13 +493,6 @@
         <severity>5</severity>
         <type>warning</type>
     </rule>
-    <rule ref="Squiz.Commenting.ClassComment">
-        <severity>5</severity>
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Commenting.ClassComment.TagNotAllowed">
-        <severity>0</severity>
-    </rule>
     <rule ref="Squiz.PHP.CommentedOutCode">
         <properties>
             <property name="maxPercentage" value="80"/>


### PR DESCRIPTION
As per upcoming updates https://github.com/magento/devdocs/pull/4425 `Squiz.Commenting.ClassComment` does not cover Magento 2 requirements and produces false positive findings.

Related tasks:
- DocBlock for function and methods https://github.com/magento/magento-coding-standard/issues/54
- DocBlock for class properties https://github.com/magento/magento-coding-standard/issues/58
- DocBlock for classes and interfaces https://github.com/magento/magento-coding-standard/issues/105
- DocBlock for constants https://github.com/magento/magento-coding-standard/issues/107