### PR TITLE
Added excludes for phtml files

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -175,6 +175,7 @@
     <rule ref="Magento2.Files.LineLength">
         <severity>8</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Magento2.NamingConvention.InterfaceName">
         <severity>8</severity>
@@ -277,6 +278,7 @@
     <rule ref="Squiz.Operators.IncrementDecrementUsage">
         <severity>7</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.Operators.ValidLogicalOperators">
         <severity>7</severity>
@@ -345,6 +347,7 @@
     <rule ref="PEAR.ControlStructures.ControlSignature">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="PSR1.Files.SideEffects">
         <severity>6</severity>
@@ -418,6 +421,9 @@
         <severity>6</severity>
         <type>warning</type>
     </rule>
+    <rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
+        <exclude-pattern>*.phtml</exclude-pattern>
+    </rule>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration">
         <severity>6</severity>
         <type>warning</type>
@@ -466,6 +472,7 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing">
         <severity>6</severity>


### PR DESCRIPTION
Added excludes for `phtml` files to keep consistency with https://github.com/magento/magento2/commit/12de4c5a9baf2972e9dbba5a82fb04213aa45f60

Additional info: https://github.com/magento/architecture/pull/160

Excludes and [ruleset.xml](https://github.com/magento/magento2/blob/2.3-develop/dev/tests/static/framework/Magento/ruleset.xml) will be removed in the future.