### PR TITLE
Bump coding standard version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "AFL-3.0"
     ],
     "type": "phpcodesniffer-standard",
-    "version": "2.0.0",
+    "version": "3",
     "require": {
         "php": ">=5.6.0",
         "squizlabs/php_codesniffer": "^3.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4b39922ceb5120fe91cae1cd3d06df8",
+    "content-hash": "6e0d85fb2347ee5e2860565481869ff7",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
As per architecture requirements and [new versioning policy](https://github.com/magento/magento-coding-standard/wiki/Magento-Coding-Standard-Versioning) v.3 release preparation.