### PR TITLE
Prevent none zero exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You can achieve this by adding the following to your project's `composer.json`:
 ````
 "scripts": {
     "post-install-cmd": [
-      "[ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/"
+      "([ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
     ],
     "post-update-cmd": [
-      "[ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/"
+      "([ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
     ]
 }
 ````

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can achieve this by adding the following to your project's `composer.json`:
       "([ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
     ],
     "post-update-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 1 ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
+      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
     ]
 }
 ````


### PR DESCRIPTION
When running `composer install --no-dev` the bash command `[ $COMPOSER_DEV_MODE -eq 1]` will cause an exit code of 1. Build environments such as bitbucket piplines will often halt the build when encountering a none zero exit code. To resolve this, we force the exit code to be 0 with some boolean logic.