### PR TITLE
No longer require a space before a colon for control structures using…

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -431,6 +431,9 @@
     <rule ref="Squiz.ControlStructures.ControlSignature">
         <severity>6</severity>
         <type>warning</type>
+        <properties>
+            <property name="requiredSpacesBeforeColon" value="0"/>
+        </properties>
     </rule>
     <rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
         <exclude-pattern>*.phtml</exclude-pattern>


### PR DESCRIPTION
… the alternative syntax

This fixes https://github.com/magento/magento-coding-standard/issues/118

Documentation: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squizcontrolstructurescontrolsignature