### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Due to security, when installed this way the Magento standard for phpcs cannot b
 You can achieve this by adding the following to your project's `composer.json`:
 ````
 "scripts": {
-    "post-install-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
+"post-install-cmd": [
+      "( [ -f vendor/bin/phpcs ] && [ -L vendor/bin/phpcs ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
     ],
     "post-update-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
+      "( [ -f vendor/bin/phpcs ] && [ -L vendor/bin/phpcs ] && vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/) || true"
     ]
 }
 ````


### PR DESCRIPTION
In composer Composer 1.9.0 2019-08-02 20:55:32 the env variable COMPOSER_DEV_MODE got been removed for post events. Please see the difference of the [post](https://github.com/composer/composer/blob/96ad0aa01fa49a39539c089ca4a1aa1a54cba98d/src/Composer/Installer.php#L321) and [pre](https://github.com/composer/composer/blob/96ad0aa01fa49a39539c089ca4a1aa1a54cba98d/src/Composer/Installer.php#L199) 
hooks.
This happend [in this commit](https://github.com/composer/composer/commit/4c4f516ea255433a27a321106d06ed330d2bd04a#diff-74425bc790838a69d0d16f06fc313edb)