### PR TITLE
Refactor PHPDoc search

### DIFF
--- a/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
@@ -56,23 +56,8 @@ class ClassAndInterfacePHPDocFormattingSniff implements Sniff
 
         $namePtr = $phpcsFile->findNext(T_STRING, $stackPtr + 1, null, false, null, true);
 
-        $commentStartPtr = $phpcsFile->findPrevious(
-            [
-                T_WHITESPACE,
-                T_DOC_COMMENT_STAR,
-                T_DOC_COMMENT_WHITESPACE,
-                T_DOC_COMMENT_TAG,
-                T_DOC_COMMENT_STRING,
-                T_DOC_COMMENT_CLOSE_TAG
-            ],
-            $stackPtr - 1,
-            null,
-            true,
-            null,
-            true
-        );
-
-        if ($tokens[$commentStartPtr]['code'] !== T_DOC_COMMENT_OPEN_TAG) {
+        $commentStartPtr = $this->PHPDocFormattingValidator->findPHPDoc($stackPtr, $phpcsFile);
+        if ($commentStartPtr === -1) {
             return;
         }
 

--- a/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
@@ -59,8 +59,8 @@ class ConstantsPHPDocFormattingSniff implements Sniff
             true
         );
 
-        $commentStartPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1, null, false, null, true);
-        if ($commentStartPtr === false) {
+        $commentStartPtr = $this->PHPDocFormattingValidator->findPHPDoc($stackPtr, $phpcsFile);
+        if ($commentStartPtr === -1) {
             return;
         }
 

--- a/Magento2/Sniffs/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Sniffs/Commenting/PHPDocFormattingValidator.php
@@ -6,11 +6,47 @@
  */
 namespace Magento2\Sniffs\Commenting;
 
+use PHP_CodeSniffer\Files\File;
+
 /**
  * Helper class for common DocBlock validations
  */
 class PHPDocFormattingValidator
 {
+    /**
+     * Finds matching PHPDoc for current pointer
+     *
+     * @param int $startPtr
+     * @param File $phpcsFile
+     * @return int
+     */
+    public function findPHPDoc($startPtr, $phpcsFile)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $commentStartPtr = $phpcsFile->findPrevious(
+            [
+                T_WHITESPACE,
+                T_DOC_COMMENT_STAR,
+                T_DOC_COMMENT_WHITESPACE,
+                T_DOC_COMMENT_TAG,
+                T_DOC_COMMENT_STRING,
+                T_DOC_COMMENT_CLOSE_TAG
+            ],
+            $startPtr - 1,
+            null,
+            true,
+            null,
+            true
+        );
+
+        if ($tokens[$commentStartPtr]['code'] !== T_DOC_COMMENT_OPEN_TAG) {
+            return -1;
+        }
+
+        return $commentStartPtr;
+    }
+
     /**
      * Determines if the comment identified by $commentStartPtr provides additional meaning to origin at $namePtr
      *

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.3.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.3.inc
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Profiler
+ */
+class Profiler
+{
+    const PROFILER = true;
+}

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.php
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.php
@@ -22,7 +22,7 @@ class ConstantsPHPDocFormattingUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList($testFile = '')
     {
-        if ($testFile === 'ConstantsPHPDocFormattingUnitTest.1.inc') {
+        if ($testFile !== 'ConstantsPHPDocFormattingUnitTest.2.inc') {
             return [];
         }
 


### PR DESCRIPTION
Resolves the issue where PHPDoc is not properly detected for constants as outlined in #134. Due to way search was done, it would fetch nearest comment, not the one belonging to current constant.