### PR TITLE
Using coding standard as s reference is causing error

### DIFF
--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -4,7 +4,7 @@
  * Copyright © Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento2\Sniffs\Commenting;
+namespace Magento2\Helpers\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 

--- a/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
@@ -6,6 +6,7 @@
  */
 namespace Magento2\Sniffs\Commenting;
 
+use Magento2\Helpers\Commenting\PHPDocFormattingValidator;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 

--- a/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
@@ -5,6 +5,7 @@
  */
 namespace Magento2\Sniffs\Commenting;
 
+use Magento2\Helpers\Commenting\PHPDocFormattingValidator;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     "autoload": {
         "classmap": [
             "PHP_CodeSniffer/Tokenizers/"
-        ]
+        ],
+        "psr-4": {
+            "Magento2\\": "Magento2/"
+        }
     },
     "scripts": {
         "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths ../../..",


### PR DESCRIPTION
magento/magento-coding-standard#144: Using coding standard as s reference is causing error