### PR TITLE
Added sniff for deprecated model methods. #187

### DIFF
--- a/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
+++ b/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Sniffs\Methods;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Detects possible use of deprecated model methods.
+ */
+class DeprecatedModelMethodSniff implements Sniff
+{
+    /**
+     * String representation of warning.
+     *
+     * @var string
+     */
+    protected $warningMessage = "Possible use of the deprecated model method 'getResource()'" .
+    " to '%s' the data detected.";
+
+    /**
+     * Warning violation code.
+     *
+     * @var string
+     */
+    protected $warningCode = 'FoundDeprecatedModelMethod';
+
+    /**
+     * List of deprecated method.
+     *
+     * @var array
+     */
+    protected $methods = [
+        'save',
+        'load',
+        'delete'
+    ];
+
+    protected $severity = 0;
+
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        return [
+            T_OBJECT_OPERATOR,
+            T_DOUBLE_COLON
+        ];
+    }
+    /**
+     * @inheritdoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $methodPosition = $phpcsFile->findNext(T_STRING, $stackPtr + 1);
+
+        if ($methodPosition !== false &&
+            in_array($tokens[$methodPosition]['content'], $this->methods)
+        ) {
+            $resourcePosition = $phpcsFile->findPrevious([T_STRING, T_VARIABLE], $stackPtr - 1);
+            if ($resourcePosition !== false) {
+                $methodName = $tokens[$resourcePosition]['content'];
+                if ($methodName === "getResource") {
+                    $phpcsFile->addWarning(
+                        sprintf($this->warningMessage, $tokens[$methodPosition]['content']),
+                        $stackPtr,
+                        $this->warningCode
+                    );
+                }
+            }
+        }
+    }
+}

--- a/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
+++ b/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
@@ -7,7 +7,6 @@ namespace Magento2\Sniffs\Methods;
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Detects possible use of deprecated model methods.
@@ -21,8 +20,7 @@ class DeprecatedModelMethodSniff implements Sniff
      *
      * @var string
      */
-    protected $warningMessage = "Possible use of the deprecated model method 'getResource()'" .
-    " to '%s' the data detected.";
+    protected $warningMessage = "The use of the deprecated method 'getResource()' to '%s' the data detected.";
 
     /**
      * Warning violation code.
@@ -69,7 +67,7 @@ class DeprecatedModelMethodSniff implements Sniff
         );
         if ($resourcePosition !== false) {
             $methodPosition = $phpcsFile->findNext([T_STRING, T_VARIABLE], $resourcePosition + 1, $endOfStatement);
-            if ($methodPosition !== false && in_array($tokens[$methodPosition]['content'], $this->methods)) {
+            if ($methodPosition !== false && in_array($tokens[$methodPosition]['content'], $this->methods, true)) {
                 $phpcsFile->addWarning(
                     sprintf($this->warningMessage, $tokens[$methodPosition]['content']),
                     $stackPtr,

--- a/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
+++ b/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
@@ -1,0 +1,4 @@
+<?php
+$model->getResource()->save();
+$model->getResource()->load();
+$model->getResource()->delete();

--- a/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
+++ b/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
@@ -1,4 +1,7 @@
 <?php
-$model->getResource()->save();
-$model->getResource()->load();
-$model->getResource()->delete();
+
+$model->getResource()->save($model);
+
+$model->getResource()->load($model, $id);
+
+$model->getResource()->delete($model);

--- a/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
+++ b/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.inc
@@ -5,3 +5,9 @@ $model->getResource()->save($model);
 $model->getResource()->load($model, $id);
 
 $model->getResource()->delete($model);
+
+$model->getResource()->myCustomMethod();
+
+$model->myCustomMethod();
+
+$model->anotherMethodWithResource()->save($model);

--- a/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.php
+++ b/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.php
@@ -23,9 +23,9 @@ class DeprecatedModelMethodUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            2 => 1,
             3 => 1,
-            4 => 1
+            5 => 1,
+            7 => 1,
         ];
     }
 }

--- a/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.php
+++ b/Magento2/Tests/Methods/DeprecatedModelMethodUnitTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Tests\Methods;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class DeprecatedModelMethodUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [
+            2 => 1,
+            3 => 1,
+            4 => 1
+        ];
+    }
+}

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -215,6 +215,10 @@
         <severity>8</severity>
         <type>warning</type>
     </rule>
+    <rule ref="Magento2.Methods.DeprecatedModelMethod">
+        <severity>8</severity>
+        <type>warning</type>
+    </rule>
 
     <!-- Severity 7 warnings: General code issues. -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax">


### PR DESCRIPTION
Added sniff for #187 to discourage the use of Resource class from Model class.

Trigger Methods: 

- getResource()->load($object)
- getResource()->save($object)
- getResource()->delete($object)

Message: `Possible use of the deprecated model method 'getResource()' to 'save' the data detected.`
