### PR TITLE
Discourage local-FS-only methods

### DIFF
--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.md
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.md
@@ -2,7 +2,7 @@
 
 ## Reason
 
-[getimagesize()](https://www.php.net/manual/en/function.getimagesize.php) function works only with local and supported streams. 
+[getimagesize](https://www.php.net/manual/en/function.getimagesize.php) function works only with local and supported streams. 
 With introduction of more advanced storages, like AWS S3 or Azure Blob Storage this function will cause issues where file is not accessible.
 
 ## How to fix

--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.md
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.md
@@ -1,0 +1,11 @@
+# Rule: getimagesize() is discouraged
+
+## Reason
+
+[getimagesize()](https://www.php.net/manual/en/function.getimagesize.php) function works only with local and supported streams. 
+With introduction of more advanced storages, like AWS S3 or Azure Blob Storage this function will cause issues where file is not accessible.
+
+## How to fix
+
+[getimagesizefromstring](https://www.php.net/manual/en/function.getimagesizefromstring.php) can be used instead to retrieve all the information from file.
+This function works with data strings, so you should read the file content using specific adapter before using it.

--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
@@ -228,5 +228,6 @@ class DiscouragedFunctionSniff extends ForbiddenFunctionsSniff
         '^intval$' => '(int) construction',
         '^strval$' => '(string) construction',
         '^htmlspecialchars$' => '\Magento\Framework\Escaper->escapeHtml',
+        'getimagesize' => 'getimagesizefromstring',
     ];
 }

--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
@@ -228,6 +228,6 @@ class DiscouragedFunctionSniff extends ForbiddenFunctionsSniff
         '^intval$' => '(int) construction',
         '^strval$' => '(string) construction',
         '^htmlspecialchars$' => '\Magento\Framework\Escaper->escapeHtml',
-        'getimagesize' => 'getimagesizefromstring',
+        '^getimagesize$' => 'getimagesizefromstring',
     ];
 }


### PR DESCRIPTION
This PR adds` getimagesize()`  to discouraged functions as it does not work with remote storage implementations.

Task: https://jira.corp.magento.com/browse/MC-38508