### PR TITLE
Avoid infinite loop when Parse Error occurs

### DIFF
--- a/Magento2/Sniffs/Security/XssTemplateSniff.php
+++ b/Magento2/Sniffs/Security/XssTemplateSniff.php
@@ -249,8 +249,10 @@ class XssTemplateSniff implements Sniff
         $posOfLastInlineThen = $this->findLastInScope(T_INLINE_THEN, $start, $end);
         if ($posOfLastInlineThen !== false) {
             $posOfInlineElse = $this->file->findNext(T_INLINE_ELSE, $posOfLastInlineThen, $end);
-            $this->addStatement($posOfLastInlineThen + 1, $posOfInlineElse);
-            $this->addStatement($posOfInlineElse + 1, $end);
+            if ($posOfInlineElse !== false) {
+                $this->addStatement($posOfLastInlineThen + 1, $posOfInlineElse);
+                $this->addStatement($posOfInlineElse + 1, $end);
+            }
             $parsed = true;
         } else {
             do {

--- a/Magento2/Tests/Security/XssTemplateUnitTest.inc
+++ b/Magento2/Tests/Security/XssTemplateUnitTest.inc
@@ -57,3 +57,6 @@ echo $var;
 <?php echo $block->escapeCss($css); ?>
 <?php echo $block->getJsLayout($jsLayout); ?>
 <?= /* @noEscape */ json_encode($config) ?>
+
+<!-- intentional parse error -->
+<?= $block->escapeUrl($block->getUrl('no-route')) <?= $block->getBaseUrl() ?>


### PR DESCRIPTION
One of our developers introduced a Parse Error into a template file. When `phpcs --standard=Magento2` ran as part of our automated testing process, it began using 100% CPU and never exited (until it was terminated automatically for taking too long). Investigation shows that the XSS Template sniff from this repository is at fault. I've managed to narrow down the cause and produced a testcase to reproduce this scenario. The proposed fix checks the return code of `PHP_CodeSniffer\Files\File::findNext()`, rather than blindly assuming this is an integer. I've not searched for other uses of this function within this codebase.