### PR TITLE
Run tests on Github Actions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['5.6', '7.0', '7.0', '7.1', '7.2', '7.3', '7.4']
+    name: Tests with PHP ${{ matrix.php-versions }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+      env:
+        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Validate composer
+      run: composer validate
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+    - name: Install dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-interaction
+
+    - name: Run unit tests suite
+      run: vendor/bin/phpunit
+
+    - name: Run code style suite
+      run: vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,6 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     name: Tests with PHP ${{ matrix.php-versions }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.6', '7.0', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     name: Tests with PHP ${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
As Travis stopped to work for some reason - I suggest moving to Github Actions, similar to https://github.com/magento/magento-semver/pull/62.

These changes I tested on my own repo - everything works fine:
https://github.com/ihor-sviziev/magento-coding-standard/runs/3143801880?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1873745/126787692-aa67884b-7fa1-417f-84e8-791567e49b93.png)
