### PR TITLE
Test on lowest and highest dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,11 +10,25 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
-    name: Tests with PHP ${{ matrix.php-versions }}
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+        dependencies:
+          - "lowest"
+          - "highest"
+        experimental:
+          - false
+        include:
+          - php-version: "8.0"
+            dependencies: "highest"
+            composer-options: "--ignore-platform-reqs"
+            experimental: true
+    name: Tests with PHP ${{ matrix.php-version }} and ${{ matrix.dependencies }} dependencies
 
     steps:
     - uses: actions/checkout@v2
@@ -22,24 +36,18 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-version }}
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Validate composer
       run: composer validate
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
+    - name: Composer install
+      uses: "ramsey/composer-install@v1"
       with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-    - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-interaction
+        dependency-versions: "${{ matrix.dependencies }}"
+        composer-options: "${{ matrix.composer-options }}"
 
     - name: Run unit tests suite
       run: vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +26,6 @@ jobs:
           - php-version: "8.0"
             dependencies: "highest"
             composer-options: "--ignore-platform-reqs"
-            experimental: true
     name: Tests with PHP ${{ matrix.php-version }} and ${{ matrix.dependencies }} dependencies
 
     steps:


### PR DESCRIPTION
This PR changes running tests on all supported PHP versions (7.2, 7.3, 7.4, 8.0) on the highest and lowest dependency versions to make sure we don't have any issues with dependencies.

Notes:
- The phpcs is **not** compatible with PHPUnit 8 and PHPUnit 9, which is required for PHP 8.  But the only latest version works fine with _ignoring platform requirements_ in composer. For now, we're ignoring them for PHP 8.0.
- PHP 8 is supported by phpcs 3.6.0. In prev. versions there were, so I'm running PHP 8 with only the highest dependencies
- As PHP 8 builds is failing - I added continue on error only for this type of builds, so the entire CI isn't failing (https://github.com/magento/magento-coding-standard/actions/runs/1070813599)
![image](https://user-images.githubusercontent.com/1873745/127141064-6ddedf22-f51c-484a-8279-0151b1f8964f.png)

- I tested this PR together with #205 - it fixes errors on PHP 8. 