### PR TITLE
Add test coverage for HtmlBindingSniff

### DIFF
--- a/Magento2/Sniffs/Html/HtmlBindingSniff.php
+++ b/Magento2/Sniffs/Html/HtmlBindingSniff.php
@@ -83,7 +83,7 @@ class HtmlBindingSniff implements Sniff
                     . ' - "' . $htmlBinding . '" doesn\'t,' . PHP_EOL
                     . 'consider using text binding if the value is supposed to be text',
                     null,
-                    'UIComponentTemplate.KnockoutBinding.HtmlSuffix'
+                    'KnockoutBindingHtmlSuffix'
                 );
             }
         }

--- a/Magento2/Tests/Html/HtmlBindingSniffUnitTest.1.inc
+++ b/Magento2/Tests/Html/HtmlBindingSniffUnitTest.1.inc
@@ -1,0 +1,30 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+<div data-bind="attr: test.value"></div>
+<p>Test</p>
+<span data-bind="html: testError()"></span>
+<div data-bind="
+    attr : tst,
+    html: test.getSomething().value.error()
+"></div>
+<p data-bind="html: '<b>Some html</b>', attr: test"></p>
+<div data-bind="html: valueUnsanitizedHtml"></div>
+<div data-bind="attr: testhtml, html: valueUnsanitizedHtml()"></div>
+<p data-bind="other_html: bind, html: bind_stuff(1, 2)"></p>
+
+<div style="tst()"></div>
+<span html="testError()"></span>
+<div html="
+    test.getSomething().value.error(1)
+"></div>
+<p html="'<b>Some html</b>'"></p>
+<div html="valueUnsanitizedHtml"></div>
+<div html="
+valueUnsanitizedHtml('test')
+"></div>
+<p html="bind_stuff()"></p>

--- a/Magento2/Tests/Html/HtmlBindingUnitTest.php
+++ b/Magento2/Tests/Html/HtmlBindingUnitTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Tests\Html;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class HtmlBindingUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [1 => 6];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This is port of the following test:
https://github.com/magento/magento2/blob/7c6b6365a3c099509d6f6e6c306cb1821910aab0/dev/tests/static/framework/tests/unit/testsuite/Magento/Sniffs/Html/HtmlBindingSniffTest.php
