### PR TITLE
AC-601: Create phpcs static check for AbstractBlockTest

### DIFF
--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -1,9 +1,10 @@
 <?php
-declare( strict_types = 1 );
 /**
  * Copyright © Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types = 1);
+
 namespace Magento2\Sniffs\Legacy;
 
 use PHP_CodeSniffer\Files\File;
@@ -66,10 +67,10 @@ class AbstractBlockSniff implements Sniff
     /**
      * Return if it is applicable to do the check
      *
-     * @param String $content
+     * @param string $content
      * @return bool
      */
-    private function isApplicable(String $content): bool
+    private function isApplicable(string $content): bool
     {
         return in_array($content, [self::CHILD_HTML_METHOD, self::CHILD_CHILD_HTML_METHOD]);
     }

--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 /**
  * Copyright © Magento. All rights reserved.
  * See COPYING.txt for license details.

--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -16,7 +16,7 @@ class AbstractBlockSniff implements Sniff
     private const CHILD_CHILD_HTML_METHOD = 'getChildChildHtml';
 
     /**
-     * Warning violation code.
+     * Error violation code.
      *
      * @var string
      */

--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Sniffs\Legacy;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class AbstractBlockSniff implements Sniff
+{
+    const CHILD_HTML_METHOD = 'getChildHtml';
+    const CHILD_CHILD_HTML_METHOD = 'getChildChildHtml';
+
+    /**
+     * Warning violation code.
+     *
+     * @var string
+     */
+    protected $errorCode = 'FoundCountOfParametersIncorrect';
+
+    /**
+     * @inheritdoc
+     */
+    public function register(): array
+    {
+        return [
+            T_OBJECT_OPERATOR
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (!isset($phpcsFile->getTokens()[$stackPtr + 1]['content'])) {
+            return;
+        }
+        $content = $phpcsFile->getTokens()[$stackPtr + 1]['content'];
+        $isTheNextMethodGetChildSomething = in_array(
+            $content,
+            [
+                self::CHILD_HTML_METHOD,
+                self::CHILD_CHILD_HTML_METHOD
+            ]
+        );
+        if (!$isTheNextMethodGetChildSomething) {
+            return;
+        }
+
+        $paramsCount = $this->getParametersCount($phpcsFile, $stackPtr + 1);
+        if ($content === self::CHILD_HTML_METHOD && $paramsCount >= 3) {
+            $phpcsFile->addError(
+                '3rd parameter is not needed anymore for getChildHtml()',
+                $stackPtr,
+                $this->errorCode
+            );
+        }
+        if ($content === self::CHILD_CHILD_HTML_METHOD && $paramsCount >= 4) {
+            $phpcsFile->addError(
+                '4th parameter is not needed anymore for getChildChildHtml()',
+                $stackPtr,
+                $this->errorCode
+            );
+        }
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $methodHtmlPosition
+     * @return int
+     */
+    private function getParametersCount(File $phpcsFile, int $methodHtmlPosition): int
+    {
+        $closePosition = $phpcsFile->getTokens()[$methodHtmlPosition +1]['parenthesis_closer'];
+        $getTokenAsContent = $phpcsFile->getTokensAsString(
+            $methodHtmlPosition + 2, 
+            ($closePosition - $methodHtmlPosition) - 2
+        );
+        if ($getTokenAsContent) {
+            $parameters = explode(',' , $getTokenAsContent);
+            return count($parameters);
+        }
+        return 0;
+    }
+}

--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -68,6 +68,8 @@ class AbstractBlockSniff implements Sniff
     }
 
     /**
+     * Get the quantity of parameters on a method
+     *
      * @param File $phpcsFile
      * @param int $methodHtmlPosition
      * @return int
@@ -76,11 +78,11 @@ class AbstractBlockSniff implements Sniff
     {
         $closePosition = $phpcsFile->getTokens()[$methodHtmlPosition +1]['parenthesis_closer'];
         $getTokenAsContent = $phpcsFile->getTokensAsString(
-            $methodHtmlPosition + 2, 
+            $methodHtmlPosition + 2,
             ($closePosition - $methodHtmlPosition) - 2
         );
         if ($getTokenAsContent) {
-            $parameters = explode(',' , $getTokenAsContent);
+            $parameters = explode(',', $getTokenAsContent);
             return count($parameters);
         }
         return 0;

--- a/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
+++ b/Magento2/Sniffs/Legacy/AbstractBlockSniff.php
@@ -10,8 +10,8 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 
 class AbstractBlockSniff implements Sniff
 {
-    const CHILD_HTML_METHOD = 'getChildHtml';
-    const CHILD_CHILD_HTML_METHOD = 'getChildChildHtml';
+    private const CHILD_HTML_METHOD = 'getChildHtml';
+    private const CHILD_CHILD_HTML_METHOD = 'getChildChildHtml';
 
     /**
      * Warning violation code.
@@ -38,18 +38,13 @@ class AbstractBlockSniff implements Sniff
         if (!isset($phpcsFile->getTokens()[$stackPtr + 1]['content'])) {
             return;
         }
+
         $content = $phpcsFile->getTokens()[$stackPtr + 1]['content'];
-        $isTheNextMethodGetChildSomething = in_array(
-            $content,
-            [
-                self::CHILD_HTML_METHOD,
-                self::CHILD_CHILD_HTML_METHOD
-            ]
-        );
-        if (!$isTheNextMethodGetChildSomething) {
+
+        if (!$this->isApplicable($content)) {
             return;
         }
-
+        
         $paramsCount = $this->getParametersCount($phpcsFile, $stackPtr + 1);
         if ($content === self::CHILD_HTML_METHOD && $paramsCount >= 3) {
             $phpcsFile->addError(
@@ -65,6 +60,17 @@ class AbstractBlockSniff implements Sniff
                 $this->errorCode
             );
         }
+    }
+
+    /**
+     * Return if it is applicable to do the check
+     *
+     * @param String $content
+     * @return bool
+     */
+    private function isApplicable(String $content): bool
+    {
+        return in_array($content, [self::CHILD_HTML_METHOD, self::CHILD_CHILD_HTML_METHOD]);
     }
 
     /**

--- a/Magento2/Tests/Legacy/AbstractBlockUnitTest.inc
+++ b/Magento2/Tests/Legacy/AbstractBlockUnitTest.inc
@@ -1,0 +1,36 @@
+<?php
+
+return $this->getChildHtml(
+    function($param){
+        $param->something();
+    },
+    'aa'
+);
+
+$this->getChildHtml(
+    function($param){
+        $param->something();
+    },
+    'aa',
+    2
+);
+
+return $this->getChildHtml('aa', 'bb');
+
+return $this->getChildHtml('aa', 'bb', 1, true);
+
+$this->getChildHtml();
+
+$this->testMethod()->getChildHtml('aa', 'bb', 'cc');
+
+$this->getChildChildHtml('aa', true, 'cc');
+
+$this->getChildChildHtml('aa', true, 'cc', 1);
+
+$this->getChildChildHtml('aa' . 'bb', !(1 + 1) * (int) $this, 'cc', 1);
+
+private function getChildHtml($aa, $bb, $cc = 'cc')
+{
+}
+
+$this->getChilChilddHtml();

--- a/Magento2/Tests/Legacy/AbstractBlockUnitTest.php
+++ b/Magento2/Tests/Legacy/AbstractBlockUnitTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Tests\Legacy;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class AbstractBlockUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [
+            10 => 1,
+            20 => 1,
+            24 => 1,
+            28 => 1,
+            30 => 1
+        ];
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -105,6 +105,10 @@
         <severity>10</severity>
         <type>error</type>
     </rule>
+    <rule ref="Magento2.Legacy.AbstractBlock">
+        <severity>10</severity>
+        <type>error</type>
+    </rule>
 
     <!-- Severity 9 warnings: Possible security and issues that may cause bugs. -->
     <rule ref="Generic.Files.ByteOrderMark">


### PR DESCRIPTION
[AC-601](https://jira.corp.magento.com/browse/AC-601): Create phpcs static check for AbstractBlockTest

This PR is to start moving the legacy static checks we have on Magento2 codebase. This is covering the **AbstractBlock** changes.