### PR TITLE
Fix ImportsFromTestNamespace from lock on group use with trailing comma

### DIFF
--- a/Magento2/Sniffs/Namespaces/ImportsFromTestNamespaceSniff.php
+++ b/Magento2/Sniffs/Namespaces/ImportsFromTestNamespaceSniff.php
@@ -57,11 +57,13 @@ class ImportsFromTestNamespaceSniff implements Sniff
             $closingCurly = $phpcsFile->findNext(T_CLOSE_USE_GROUP, ($next + 1));
             do {
                 $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), $closingCurly, true);
-                $groupedAsContent = $baseUse. $tokens[$next]['content'];
-                $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $closingCurly);
-                if (strpos($groupedAsContent, $this->prohibitNamespace) !== false) {
-                    $phpcsFile->addWarning($this->warningMessage, $stackPtr, $this->warningCode);
-                    return;
+                if ($next !== false) {
+                    $groupedAsContent = $baseUse. $tokens[$next]['content'];
+                    $next = $phpcsFile->findNext(T_COMMA, ($next + 1), $closingCurly);
+                    if (strpos($groupedAsContent, $this->prohibitNamespace) !== false) {
+                        $phpcsFile->addWarning($this->warningMessage, $stackPtr, $this->warningCode);
+                        return;
+                    }
                 }
             } while ($next !== false);
         }

--- a/Magento2/Tests/Namespaces/ImportsFromTestNamespaceUnitTest.inc
+++ b/Magento2/Tests/Namespaces/ImportsFromTestNamespaceUnitTest.inc
@@ -4,3 +4,4 @@ use Magento\Foo\Tests as FakeTest;
 use Magento\Real\Classes;
 use \Magento\{Tests\String, Tests\Int};
 use \Magento\{Foo\string, Bar\float};
+use \Foo\{Trailing, Space,};


### PR DESCRIPTION
If a grouped use statement has a trailing coma like this:
```
use Magento\Something{
  Foo,
  Bar,
};
```
`findNext` on line 59 was returning false and next call was starting to search again from line 1 (`$next + 1`) and this function was looping indefinitely through input tokens.