### PR TITLE
Ignore PHPUnit results cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .project/
 .settings/
 .vscode/
+
+.phpunit.result.cache


### PR DESCRIPTION
This file gets created when running `vendor/bin/phpunit` and should not be tracked in version control.