### PR TITLE
Fix PHP Fatal error when docblock is invalid

### DIFF
--- a/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php
+++ b/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php
@@ -609,8 +609,6 @@ class MethodArgumentsSniff implements Sniff
      * @param File $phpcsFile
      * @param array $paramPointers
      *
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
-     *
      * @see https://devdocs.magento.com/guides/v2.4/coding-standards/docblock-standard-general.html#format-consistency
      */
     private function validateFormattingConsistency(
@@ -626,7 +624,9 @@ class MethodArgumentsSniff implements Sniff
             if (isset($paramPointers[$ptr])) {
                 $paramContent = $tokens[$paramPointers[$ptr] + 2]['content'];
                 $paramDefinition = $paramDefinitions[$ptr];
-                $argumentPositions[] = strpos($paramContent, $paramDefinition['paramName']);
+                if (isset($paramDefinition['paramName'])) {
+                    $argumentPositions[] = strpos($paramContent, $paramDefinition['paramName']);
+                }
                 $commentPositions[] = $paramDefinition['comment']
                     ? strrpos($paramContent, $paramDefinition['comment']) : null;
             }

--- a/Magento2/Tests/Annotation/MethodArgumentsUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodArgumentsUnitTest.inc
@@ -22,3 +22,14 @@ public function setExtensionAs(\Magento\Catalog\Api\Data\CategoryExtensionInterf
 {
     return $this->_setExtensionAttributes($extensionAttributes);
 }
+
+/**
+ * Short description of method
+ *
+ * @param int
+ * @return int
+ */
+public function invalidDocBlockShouldNotCauseFatalErrorInSniff(int $number): int
+{
+    return $number;
+}

--- a/Magento2/Tests/Annotation/MethodArgumentsUnitTest.php
+++ b/Magento2/Tests/Annotation/MethodArgumentsUnitTest.php
@@ -16,10 +16,11 @@ class MethodArgumentsUnitTest extends AbstractSniffUnitTest
     {
         return [
             12 => 1,
-            21 => 1
+            21 => 1,
+            32 => 1,
         ];
     }
-    
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
We're seeing the following error when running Magento coding standard version 8 on one of the website we inherited:

    PHP Fatal error:  Uncaught TypeError: strpos(): Argument #2 ($needle) must be of type string, null given in /srv/www/vendor/magento/magento-coding-standard/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php:629
    Stack trace:
    #0 /srv/www/vendor/magento/magento-coding-standard/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php(629): strpos('\\VendorName\\Mod...', NULL)
    #1 /srv/www/vendor/magento/magento-coding-standard/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php(515): Magento2\Sniffs\Annotation\MethodArgumentsSniff->validateFormattingConsistency(Array, Array, Object(PHP_CodeSniffer\Files\LocalFile), Array)
    #2 /srv/www/vendor/magento/magento-coding-standard/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php(600): Magento2\Sniffs\Annotation\MethodArgumentsSniff->validateMethodParameterAnnotations(385, Array, Array, Object(PHP_CodeSniffer\Files\LocalFile), Array, 356, 380)
    #3 /srv/www/vendor/squizlabs/php_codesniffer/src/Files/File.php(498): Magento2\Sniffs\Annotation\MethodArgumentsSniff->process(Object(PHP_CodeSniffer\Files\LocalFile), 385)
    #4 /srv/www/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php(92): PHP_CodeSniffer\Files\File->process()
    #5 /srv/www/vendor/squizlabs/php_codesniffer/src/Runner.php(630): PHP_CodeSniffer\Files\LocalFile->process()
    #6 /srv/www/vendor/squizlabs/php_codesniffer/src/Runner.php(434): PHP_CodeSniffer\Runner->processFile(Object(PHP_CodeSniffer\Files\LocalFile))
    #7 /srv/www/vendor/squizlabs/php_codesniffer/src/Runner.php(114): PHP_CodeSniffer\Runner->run()
    #8 /srv/www/vendor/squizlabs/php_codesniffer/bin/phpcs(18): PHP_CodeSniffer\Runner->runPHPCS()
    #9 {main}
      thrown in /srv/www/vendor/magento/magento-coding-standard/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php on line 629

This pull request adds a test to cover this and fixes the bug.