### PR TITLE
AC-1100 Catch badly put newlines in LESS files

### DIFF
--- a/Magento2/Sniffs/Less/ColonSpacingSniff.php
+++ b/Magento2/Sniffs/Less/ColonSpacingSniff.php
@@ -40,6 +40,12 @@ class ColonSpacingSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        $nextSemicolon = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
+        if (false !== $nextSemicolon && ($tokens[$nextSemicolon]['line'] !== $tokens[$stackPtr]['line'])) {
+            $error = 'Expected 1 space after colon in style definition; newline found';
+            $phpcsFile->addError($error, $stackPtr, 'AfterNewline');
+        }
+        
         if ($this->needValidateSpaces($phpcsFile, $stackPtr, $tokens)) {
             $this->validateSpaces($phpcsFile, $stackPtr, $tokens);
         }
@@ -56,12 +62,7 @@ class ColonSpacingSniff implements Sniff
      */
     private function needValidateSpaces(File $phpcsFile, $stackPtr, $tokens)
     {
-        $nextSemicolon = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
-
-        if (false === $nextSemicolon
-            || ($tokens[$nextSemicolon]['line'] !== $tokens[$stackPtr]['line'])
-            || TokenizerSymbolsInterface::BITWISE_AND === $tokens[$stackPtr - 1]['content']
-        ) {
+        if (TokenizerSymbolsInterface::BITWISE_AND === $tokens[$stackPtr - 1]['content']) {
             return false;
         }
 
@@ -98,15 +99,12 @@ class ColonSpacingSniff implements Sniff
             $phpcsFile->addError('Expected 1 space after colon in style definition; 0 found', $stackPtr, 'NoneAfter');
         } else {
             $content = $tokens[($stackPtr + 1)]['content'];
-            if (false === strpos($content, $phpcsFile->eolChar)) {
+            if (false !== strpos($content, ' ')) {
                 $length  = strlen($content);
                 if ($length !== 1) {
                     $error = sprintf('Expected 1 space after colon in style definition; %s found', $length);
                     $phpcsFile->addError($error, $stackPtr, 'After');
                 }
-            } else {
-                $error = 'Expected 1 space after colon in style definition; newline found';
-                $phpcsFile->addError($error, $stackPtr, 'AfterNewline');
             }
         }
     }

--- a/Magento2/Sniffs/Less/ColonSpacingSniff.php
+++ b/Magento2/Sniffs/Less/ColonSpacingSniff.php
@@ -39,7 +39,7 @@ class ColonSpacingSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        
+
         if ($this->needValidateSpaces($phpcsFile, $stackPtr, $tokens)) {
             $this->validateSpaces($phpcsFile, $stackPtr, $tokens);
         }
@@ -75,7 +75,10 @@ class ColonSpacingSniff implements Sniff
     }
 
     /**
-     * Validate Colon Spacing according to requirements
+     * Validate Colon Spacing according to requirements:
+     * - No spaces before colon
+     * - Exactly 1 space after colon
+     * - No property definition scattered among several lines
      *
      * @param File $phpcsFile
      * @param int $stackPtr

--- a/Magento2/Sniffs/Less/ColonSpacingSniff.php
+++ b/Magento2/Sniffs/Less/ColonSpacingSniff.php
@@ -39,12 +39,6 @@ class ColonSpacingSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-
-        $nextSemicolon = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
-        if (false !== $nextSemicolon && ($tokens[$nextSemicolon]['line'] !== $tokens[$stackPtr]['line'])) {
-            $error = 'Expected 1 space after colon in style definition; newline found';
-            $phpcsFile->addError($error, $stackPtr, 'AfterNewline');
-        }
         
         if ($this->needValidateSpaces($phpcsFile, $stackPtr, $tokens)) {
             $this->validateSpaces($phpcsFile, $stackPtr, $tokens);
@@ -93,6 +87,12 @@ class ColonSpacingSniff implements Sniff
     {
         if (T_WHITESPACE === $tokens[($stackPtr - 1)]['code']) {
             $phpcsFile->addError('There must be no space before a colon in a style definition', $stackPtr, 'Before');
+        }
+
+        $nextSemicolon = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
+        if (false !== $nextSemicolon && ($tokens[$nextSemicolon]['line'] !== $tokens[$stackPtr]['line'])) {
+            $error = 'Expected 1 space after colon in style definition; newline found';
+            $phpcsFile->addError($error, $stackPtr, 'AfterNewline');
         }
 
         if (T_WHITESPACE !== $tokens[($stackPtr + 1)]['code']) {

--- a/Magento2/Tests/Less/ColonSpacingUnitTest.less
+++ b/Magento2/Tests/Less/ColonSpacingUnitTest.less
@@ -13,7 +13,7 @@ div#foo {
 }
 
 .blah {
-  foo :'xyz';
+  foo :'jkl';
 }
 
 .foo {

--- a/Magento2/Tests/Less/ColonSpacingUnitTest.php
+++ b/Magento2/Tests/Less/ColonSpacingUnitTest.php
@@ -16,6 +16,7 @@ class ColonSpacingUnitTest extends AbstractLessSniffUnitTestCase
             8 => 1,
             12 => 1,
             16 => 2,
+            20 => 1,
         ];
     }
 


### PR DESCRIPTION
Catch newlines in the middle of a style definition and throw an error if any.

Resolves https://github.com/magento/magento-coding-standard/issues/242