### PR TITLE
AC-663: Create phpcs static check for ClassesTest::testPhpCode

### DIFF
--- a/Magento2/Sniffs/Legacy/ClassesPHPSniff.php
+++ b/Magento2/Sniffs/Legacy/ClassesPHPSniff.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Sniffs\Legacy;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class ClassesPHPSniff implements Sniff
+{
+
+    private const errorMessage = 'Obsolete factory name(s) detected';
+    
+    private const errorCode = 'ObsoleteFactoryName';
+
+    private $methodsThatReceiveClassNameAsFirstArgument = [
+        'getModel', 'getSingleton', 'getResourceModel', 'getResourceSingleton',
+        'addBlock', 'createBlock', 'getBlockSingleton',
+        'initReport', 'setEntityModelClass', 'setAttributeModel', 'setBackendModel', 'setFrontendModel',
+        'setSourceModel', 'setModel'
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function register(): array
+    {
+        return [
+            T_OBJECT,
+            T_DOUBLE_COLON,
+        ];
+    }
+    
+
+    /**
+     * @inheritdoc
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $methodNameStackPtr = $phpcsFile->findNext(T_STRING, $stackPtr + 1, null, false, null, true);
+        if ($methodNameStackPtr === false) {
+            return;
+        }
+        $name = $tokens[$methodNameStackPtr]['content'];
+        if (in_array($name, $this->methodsThatReceiveClassNameAsFirstArgument)) {
+            $firstArgumentStackPtr = $phpcsFile->findNext(
+                [T_CONSTANT_ENCAPSED_STRING],
+                $methodNameStackPtr + 1,
+                null,
+                false,
+                null,
+                true
+            );
+            if ($firstArgumentStackPtr === false) {
+                return;
+            }
+            $name = $tokens[$firstArgumentStackPtr]['content'];
+            if (!$this->isAValidNonFactoryName($name)) {
+                $phpcsFile->addError(
+                    self::errorMessage,
+                    $methodNameStackPtr + 1,
+                    self::errorCode,
+                );
+            }
+        }
+    }
+
+    /**
+     * Check whether specified classes or module names correspond to a file according PSR-1 Standard.
+     *
+     * @param string $name
+     * @return bool
+     */
+    private function isAValidNonFactoryName(string $name): bool
+    {
+        if (strpos($name, 'Magento') === false) {
+            return true;
+        }
+
+        if (false === strpos($name, '\\')) {
+            return false;
+        }
+
+        if (preg_match('/^([A-Z\\\\][A-Za-z\d\\\\]+)+$/', $name) !== 1) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Magento2/Tests/Legacy/ClassesPHPUnitTest.inc
+++ b/Magento2/Tests/Legacy/ClassesPHPUnitTest.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Magento;
+
+class foo_baz{};
+
+$model = Mage::getModel('Magento\foo_bar');
+$model = Mage::getModel('baz\FooBar');
+$model = Mage::getModel('Magento\FooBar');
+$model = Mage::getModel('MAGENTO\FooBar');

--- a/Magento2/Tests/Legacy/ClassesPHPUnitTest.php
+++ b/Magento2/Tests/Legacy/ClassesPHPUnitTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento2\Tests\Legacy;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ClassesPHPUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList()
+    {
+        return [
+            7 => 1,
+            9 => 1,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
@sivaschenko I'm following what is done in `dev/tests/static/testsuite/Magento/Test/Legacy/ClassesTest.php`, but I'm not sure this is the right approach. What they do is to get all occurrences of certaing methods like `getModel`, `getResourceModel`, etc. and check the parameters that correspond to a class name. Shouldn't we just check class declarations instead?

Also, I'm not sure about regexps used to check correctness of class names.