### PR TITLE
AC-1339: Detect comment for typed class properties

### DIFF
--- a/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
@@ -60,7 +60,7 @@ class ClassPropertyPHPDocFormattingSniff extends AbstractVariableSniff
 
         if ($commentEnd !== false && $tokens[$commentEnd]['code'] === T_STRING) {
             $commentEnd = $phpcsFile->findPrevious($this->ignoreTokens, ($commentEnd - 1), null, true);
-        } else if ($commentEnd === false
+        } elseif ($commentEnd === false
             || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
                 && $tokens[$commentEnd]['code'] !== T_COMMENT)
         ) {

--- a/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
@@ -57,13 +57,20 @@ class ClassPropertyPHPDocFormattingSniff extends AbstractVariableSniff
         $tokens = $phpcsFile->getTokens();
 
         $commentEnd = $phpcsFile->findPrevious($this->ignoreTokens, ($stackPtr - 1), null, true);
+
+        if ($commentEnd !== false && $tokens[$commentEnd]['code'] === T_STRING) {
+            $commentEnd = $phpcsFile->findPrevious($this->ignoreTokens, ($commentEnd - 1), null, true);
+        }
+
         if ($commentEnd === false
             || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-                && $tokens[$commentEnd]['code'] !== T_COMMENT)
+                && $tokens[$commentEnd]['code'] !== T_COMMENT
+                && $tokens[$commentEnd]['code'] !== T_STRING)
         ) {
             $phpcsFile->addWarning('Missing PHP DocBlock for class property.', $stackPtr, 'Missing');
             return;
         }
+
         $commentStart = $tokens[$commentEnd]['comment_opener'];
         $foundVar = null;
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {

--- a/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
@@ -60,12 +60,9 @@ class ClassPropertyPHPDocFormattingSniff extends AbstractVariableSniff
 
         if ($commentEnd !== false && $tokens[$commentEnd]['code'] === T_STRING) {
             $commentEnd = $phpcsFile->findPrevious($this->ignoreTokens, ($commentEnd - 1), null, true);
-        }
-
-        if ($commentEnd === false
+        } else if ($commentEnd === false
             || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
-                && $tokens[$commentEnd]['code'] !== T_COMMENT
-                && $tokens[$commentEnd]['code'] !== T_STRING)
+                && $tokens[$commentEnd]['code'] !== T_COMMENT)
         ) {
             $phpcsFile->addWarning('Missing PHP DocBlock for class property.', $stackPtr, 'Missing');
             return;

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -125,5 +125,4 @@ class correctlyFormattedClassMemberDocBlock
      * @var string
      */
     protected string $test;
-
 }

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -120,4 +120,10 @@ class correctlyFormattedClassMemberDocBlock
      * @var test
      */
     protected $test;
+
+    /**
+     * @var string
+     */
+    protected string $test;
+
 }


### PR DESCRIPTION
Avoid triggering the "Missing PHP DocBlock for class property." warning when using typed class properties.