### PR TITLE
Add Sniff for check autovivification on array

### DIFF
--- a/Magento2/Sniffs/PHP/ArrayAutovivificationSniff.php
+++ b/Magento2/Sniffs/PHP/ArrayAutovivificationSniff.php
@@ -48,12 +48,15 @@ class ArrayAutovivificationSniff implements Sniff
 
         if ($positionSquareBracket) {
             $tokens = $phpcsFile->getTokens();
-            $propertyTokenKey = array_keys(array_column($tokens, 'content'), $tokens[$stackPtr]['content']);
+            $positionFunction = $phpcsFile->findPrevious(T_FUNCTION, $positionSquareBracket) ?: 0;
+            $sliceLength = $stackPtr - $positionFunction;
+            $sliceToken = array_slice(array_column($tokens, 'content'), $positionFunction, $sliceLength, true);
+            $propertyTokenKey = array_keys($sliceToken, $tokens[$stackPtr]['content']);
 
             arsort($propertyTokenKey);
 
             foreach ($propertyTokenKey as $tokenKey) {
-                if ($tokenKey < $stackPtr && $tokens[$tokenKey + 2]['content'] === '=') {
+                if ($tokens[$tokenKey + 2]['content'] === '=') {
                     if ($tokens[$tokenKey + 4]['content'] != 'false') {
                         return;
                     }

--- a/Magento2/Sniffs/PHP/ArrayAutovivificationSniff.php
+++ b/Magento2/Sniffs/PHP/ArrayAutovivificationSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento2\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Sniff to validate array autovivification.
+ */
+class ArrayAutovivificationSniff implements Sniff
+{
+    /**
+     * String representation of error.
+     *
+     * @var string
+     */
+    private $warningMessage = 'Deprecated: Automatic conversion of false to array is deprecated.';
+
+    /**
+     * Warning violation code.
+     *
+     * @var string
+     */
+    private $warningCode = 'Autovivification';
+
+    /**
+     * @inheritdoc
+     */
+    public function register(): array
+    {
+        return [
+            T_VARIABLE
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $positionSquareBracket = $phpcsFile->findNext(T_OPEN_SQUARE_BRACKET, $stackPtr, $stackPtr + 2);
+
+        if ($positionSquareBracket) {
+            $tokens = $phpcsFile->getTokens();
+            $propertyTokenKey = array_keys(array_column($tokens, 'content'), $tokens[$stackPtr]['content']);
+
+            arsort($propertyTokenKey);
+
+            foreach ($propertyTokenKey as $tokenKey) {
+                if ($tokenKey < $stackPtr && $tokens[$tokenKey + 2]['content'] === '=') {
+                    if ($tokens[$tokenKey + 4]['content'] != 'false') {
+                        return;
+                    }
+
+                    $phpcsFile->addWarning($this->warningMessage, $positionSquareBracket, $this->warningCode);
+                }
+            }
+        }
+    }
+}

--- a/Magento2/Tests/PHP/ArrayAutovivificationUnitTest.inc
+++ b/Magento2/Tests/PHP/ArrayAutovivificationUnitTest.inc
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento2\Tests\PHP;
+
+/**
+ * Class to test array avtovivification.
+ */
+class Avtovivification
+{
+    /**
+     * @return array
+     */
+    public function testNullAvtovivification()
+    {
+        $productIds = null;
+
+        $productIds[] = 'test_array_value';
+
+        return $productIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function testArrayAvtovivification()
+    {
+        $productIds = [];
+
+        $productIds[] = 'test_array_value';
+
+        return $productIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function testFalseAvtovivification()
+    {
+        $productIds = false;
+
+        $productIds[] = 'test_array_value';
+
+        return $productIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function testUndefineAvtovivification()
+    {
+        $productIds[] = 'test_array_value';
+
+        return $productIds;
+    }
+}

--- a/Magento2/Tests/PHP/ArrayAutovivificationUnitTest.php
+++ b/Magento2/Tests/PHP/ArrayAutovivificationUnitTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento2\Tests\PHP;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
+class ArrayAutovivificationUnitTest extends AbstractSniffUnitTest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getErrorList(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWarningList($testFile = ''): array
+    {
+        if ($testFile === 'ArrayAutovivificationUnitTest.inc') {
+            return [
+                46 => 1
+            ];
+        }
+
+        return [];
+    }
+}

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -400,6 +400,11 @@
         <type>warning</type>
         <exclude-pattern>*\.xml$</exclude-pattern>
     </rule>
+    <rule ref="Magento2.PHP.ArrayAutovivification">
+        <severity>7</severity>
+        <type>warning</type>
+        <exclude-pattern>*\.xml$</exclude-pattern>
+    </rule>
     <rule ref="Magento2.Performance.ForeachArrayMerge">
         <severity>7</severity>
         <type>warning</type>


### PR DESCRIPTION
### Description (*)

Added sniff for check autovivification on array.

Addresses backward incompatible change in PHP 8.1: https://wiki.php.net/rfc/autovivification_false

### Fixed Issues (if relevant)

1. magento/magento2#34509


### Contribution checklist (*)
 - [ ] Author has signed the [Adobe CLA](https://opensource.adobe.com/cla.html)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)