### PR TITLE
Excluded JS files for PSR sniffs

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -502,6 +502,7 @@
         </properties>
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*\.js$</exclude-pattern>
     </rule>
     <rule ref="Magento2.GraphQL.ValidArgumentName">
         <severity>6</severity>
@@ -577,6 +578,7 @@
     <rule ref="PSR2.Methods.FunctionCallSignature">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*\.js$</exclude-pattern>
     </rule>
     <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterCloseBracket">
         <severity>0</severity>


### PR DESCRIPTION
Excluded JS files for PSR sniffs and the indents requirements might conflict with eslint static tests