### PR TITLE
AC-1509: Remove outdated JSCS static tests from magento

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Also, verify that the sniffer code itself is written according to the Magento Co
 vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php
 ```
 
-### ESLint and JSCS
+### ESLint
 Prerequisites: [Node.js](https://nodejs.org/) (`^12.22.0`, `^14.17.0`, or `>=16.0.0`).
 
 You need to run the following command to install all the necessary packages described in the `package.json` file:
@@ -107,15 +107,11 @@ You need to run the following command to install all the necessary packages desc
 npm install
 ```
 
-You can just execute ESLint as follows:
+You can execute ESLint as follows:
 ```bash
 npm run eslint -- path/to/analyze
 ```
 
-Run the following command to execute JSCS:
-```bash
-npm run jscs path/to/analyze
-```
 ## License
 
 Each Magento source file included in this distribution is licensed under the OSL-3.0 license.


### PR DESCRIPTION
Remove JSCS references from README file on magento-coding-standard
https://jira.corp.magento.com/browse/AC-1509