### PR TITLE
Fix Comment block is missing Failure when Attribute is present after the docblock

### DIFF
--- a/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php
+++ b/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php
@@ -70,7 +70,23 @@ class MethodArgumentsSniff implements Sniff
     private function validateCommentBlockExists(File $phpcsFile, int $previousCommentClosePtr, int $stackPtr): bool
     {
         $tokens = $phpcsFile->getTokens();
+        $attributeFlag = false;
         for ($tempPtr = $previousCommentClosePtr + 1; $tempPtr < $stackPtr; $tempPtr++) {
+            $tokenCode = $tokens[$tempPtr]['code'];
+
+            // Ignore attributes e.g. #[\ReturnTypeWillChange]
+            if ($tokenCode === T_ATTRIBUTE_END) {
+                $attributeFlag = false;
+                continue;
+            }
+            if ($attributeFlag) {
+                continue;
+            }
+            if ($tokenCode === T_ATTRIBUTE) {
+                $attributeFlag = true;
+                continue;
+            }
+
             if (!$this->isTokenBeforeClosingCommentTagValid($tokens[$tempPtr]['type'])) {
                 return false;
             }

--- a/Magento2/Tests/Annotation/MethodArgumentsUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodArgumentsUnitTest.inc
@@ -33,3 +33,21 @@ public function invalidDocBlockShouldNotCauseFatalErrorInSniff(int $number): int
 {
     return $number;
 }
+
+/**
+ * Short description.
+ *
+ * @param string $text
+ * @return string
+ */
+#[\ReturnTypeWillChange]
+public function methodWithAttributeAndValidDocblock(string $text): string
+{
+    return $text;
+}
+
+#[\ReturnTypeWillChange]
+public function methodWithAttributeAndWithoutDocblock(string $text): string
+{
+    return $text;
+}

--- a/Magento2/Tests/Annotation/MethodArgumentsUnitTest.php
+++ b/Magento2/Tests/Annotation/MethodArgumentsUnitTest.php
@@ -18,6 +18,7 @@ class MethodArgumentsUnitTest extends AbstractSniffUnitTest
             12 => 1,
             21 => 1,
             32 => 1,
+            50 => 1
         ];
     }
 


### PR DESCRIPTION
The Warning 'Comment block is missing' is thrown when the attribute is present after the docblock.

example:
```
/**
 * Check if given type is any type.
 *
 * @param string $type
 * @return bool
 */
#[\ReturnTypeWillChange]
public function isTypeAny($type)
```

In such case our Sniff should ignore the attribute.