### PR TITLE
Require trailing commas where useful

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -12,7 +12,7 @@
         "node": true
     },
     "rules": {
-        "comma-dangle": [2, "never"],
+        "comma-dangle": [2, "always-multiline"],
         "comma-style": [2, "last"],
         "curly": [2, "all"],
         "eol-last": 2,

--- a/eslint/rules/jquery-no-andSelf.js
+++ b/eslint/rules/jquery-no-andSelf.js
@@ -5,12 +5,12 @@ module.exports = {
             description: 'Disallow the use of the deprecated `andSelf` method',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/andself/'
+            url: 'https://api.jquery.com/andself/',
         },
         schema: [],
         messages: {
-            andSelf: 'jQuery.andSelf() removed, use jQuery.addBack()'
-        }
+            andSelf: 'jQuery.andSelf() removed, use jQuery.addBack()',
+        },
     },
 
     /**
@@ -38,10 +38,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        messageId: 'andSelf'
+                        messageId: 'andSelf',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-bind-unbind.js
+++ b/eslint/rules/jquery-no-bind-unbind.js
@@ -5,12 +5,12 @@ module.exports = {
             description: 'Disallow the use of the deprecated $.bind and $.unbind',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/bind/'
+            url: 'https://api.jquery.com/bind/',
         },
         schema: [],
         messages: {
-            bind: 'jQuery $.bind and $.unbind are deprecated, use $.on and $.off instead'
-        }
+            bind: 'jQuery $.bind and $.unbind are deprecated, use $.on and $.off instead',
+        },
     },
 
     /**
@@ -38,10 +38,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        messageId: 'bind'
+                        messageId: 'bind',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-delegate-undelegate.js
+++ b/eslint/rules/jquery-no-delegate-undelegate.js
@@ -5,12 +5,12 @@ module.exports = {
             description: 'Disallow the use of the deprecated $.delegate and $.undelegate',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/delegate/'
+            url: 'https://api.jquery.com/delegate/',
         },
         schema: [],
         messages: {
-            delegate: 'jQuery $.delegate and $.undelegate are deprecated, use $.on and $.off instead'
-        }
+            delegate: 'jQuery $.delegate and $.undelegate are deprecated, use $.on and $.off instead',
+        },
     },
 
     /**
@@ -38,10 +38,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        messageId: 'delegate'
+                        messageId: 'delegate',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-deprecated-expr.js
+++ b/eslint/rules/jquery-no-deprecated-expr.js
@@ -5,9 +5,9 @@ module.exports = {
             description: 'Disallow the use of deprecated way to add to custom selectors',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/load/'
+            url: 'https://api.jquery.com/load/',
         },
-        schema: []
+        schema: [],
     },
 
     /**
@@ -31,7 +31,7 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        message: 'jQuery.expr[":"] is deprecated; Use jQuery.expr.pseudos instead'
+                        message: 'jQuery.expr[":"] is deprecated; Use jQuery.expr.pseudos instead',
                     });
                 }
             },
@@ -45,10 +45,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        message: 'jQuery.expr.filters is deprecated; Use jQuery.expr.pseudos instead'
+                        message: 'jQuery.expr.filters is deprecated; Use jQuery.expr.pseudos instead',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-event-shorthand.js
+++ b/eslint/rules/jquery-no-event-shorthand.js
@@ -5,9 +5,9 @@ module.exports = {
             description: 'Disallow the use of shorthand event methods',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/load/'
+            url: 'https://api.jquery.com/load/',
         },
-        schema: []
+        schema: [],
     },
 
     /**
@@ -30,7 +30,7 @@ module.exports = {
             CallExpression: function (node) {
                 var namesToMsg = {
                         'unload': 'jQuery.unload() was removed, use .on("unload", fn) instead.',
-                        'ready': 'jQuery.ready(handler) is deprecated and should be replaced with jQuery(handler)'
+                        'ready': 'jQuery.ready(handler) is deprecated and should be replaced with jQuery(handler)',
                     },
                     name,
                     message;
@@ -44,10 +44,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        message: message
+                        message: message,
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-input-event-shorthand.js
+++ b/eslint/rules/jquery-no-input-event-shorthand.js
@@ -5,9 +5,9 @@ module.exports = {
             description: 'Disallow the use of shortcuts to input events via keyboard/mouse trigger events',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/bind/'
+            url: 'https://api.jquery.com/bind/',
         },
-        schema: []
+        schema: [],
     },
 
     /**
@@ -43,10 +43,10 @@ module.exports = {
                     context.report({
                         node: node,
                         message: 'Instead of .' + name + '(fn) use .on("' + name + '", fn). Instead of .' + name +
-                            '() use .trigger("' + name + '")'
+                            '() use .trigger("' + name + '")',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-misc-deprecated-functions.js
+++ b/eslint/rules/jquery-no-misc-deprecated-functions.js
@@ -5,9 +5,9 @@ module.exports = {
             description: 'Disallow the use of various deprecated methods methods',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/load/'
+            url: 'https://api.jquery.com/load/',
         },
-        schema: []
+        schema: [],
     },
 
     /**
@@ -36,7 +36,7 @@ module.exports = {
                         'isArray': 'jQuery.isArray() is deprecated. ' +
                             'Use the native Array.isArray method instead',
                         'parseJSON' : 'jQuery.parseJSON() is deprecated. ' +
-                            'To parse JSON strings, use the native JSON.parse method instead'
+                            'To parse JSON strings, use the native JSON.parse method instead',
                     },
                     name,
                     message;
@@ -50,10 +50,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        message: message
+                        message: message,
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-size.js
+++ b/eslint/rules/jquery-no-size.js
@@ -5,12 +5,12 @@ module.exports = {
             description: 'Disallow the use of the deprecated `size` method',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/size/'
+            url: 'https://api.jquery.com/size/',
         },
         schema: [],
         messages: {
-            size: 'jQuery.size() removed, use jQuery.length'
-        }
+            size: 'jQuery.size() removed, use jQuery.length',
+        },
     },
 
     /**
@@ -38,10 +38,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        messageId: 'size'
+                        messageId: 'size',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/jquery-no-trim.js
+++ b/eslint/rules/jquery-no-trim.js
@@ -5,12 +5,12 @@ module.exports = {
             description: 'Disallow the use of the deprecated `trim` function',
             category: 'jQuery deprecated functions',
             recommended: true,
-            url: 'https://api.jquery.com/jQuery.trim/'
+            url: 'https://api.jquery.com/jQuery.trim/',
         },
         schema: [],
         messages: {
-            trim: 'jQuery.trim is deprecated; use String.prototype.trim'
-        }
+            trim: 'jQuery.trim is deprecated; use String.prototype.trim',
+        },
     },
 
     /**
@@ -38,10 +38,10 @@ module.exports = {
                 if (utils.isjQuery(node)) {
                     context.report({
                         node: node,
-                        messageId: 'trim'
+                        messageId: 'trim',
                     });
                 }
-            }
+            },
         };
-    }
+    },
 };

--- a/eslint/rules/utils.js
+++ b/eslint/rules/utils.js
@@ -26,7 +26,7 @@ function define(node) {
     return {
         func: defineStmt.expression,
         modulePaths: args[0].elements,
-        moduleNames: args.length > 1 && args[1].params || []
+        moduleNames: args.length > 1 && args[1].params || [],
     };
 }
 
@@ -118,5 +118,5 @@ function isjQuery(node) {
 
 module.exports = {
     traverse: getExpressionId,
-    isjQuery: isjQuery
+    isjQuery: isjQuery,
 };


### PR DESCRIPTION
This is a small part of https://github.com/magento/magento-coding-standard/pull/347 as suggested in https://github.com/magento/magento-coding-standard/pull/347#issuecomment-999512251.

https://eslint.org/docs/rules/comma-dangle
Including a trailing comma when the closing `]` or `}` is on a different line means that it's easier to see what's changed when reviewing code. Adding a new item to an array or property to an object means that only the new line needs to be added, and no existing lines need to be modified; removing an item or property means that only that line needs to be removed with others remaining unchanged.