### PR TITLE
[eslint] Enforce consistent spacing around keywords

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -19,7 +19,7 @@
         "eqeqeq": [2, "smart"],
         "guard-for-in": 2,
         "indent": [2, 4],
-        "keyword-spacing": [2, {}],
+        "keyword-spacing": [2, {"after": true, "before": true}],
         "lines-around-comment": [
             2,
             {


### PR DESCRIPTION
This is a small part of https://github.com/magento/magento-coding-standard/pull/347 as suggested in https://github.com/magento/magento-coding-standard/pull/347#issuecomment-999512251.

https://eslint.org/docs/rules/keyword-spacing