### PR TITLE
Forbid overriding built-in objects

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -50,6 +50,7 @@
         "no-fallthrough": 2,
         "no-floating-decimal": 2,
         "no-func-assign": 2,
+        "no-global-assign": 2,
         "no-implied-eval": 2,
         "no-inner-declarations": 2,
         "no-invalid-regexp": 2,


### PR DESCRIPTION
This is a small part of https://github.com/magento/magento-coding-standard/pull/347 as suggested in https://github.com/magento/magento-coding-standard/pull/347#issuecomment-999512251.

https://eslint.org/docs/rules/no-global-assign