### PR TITLE
Disallow multiple empty lines

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -58,7 +58,7 @@
         "no-loop-func": 2,
         "no-mixed-spaces-and-tabs": 2,
         "no-multi-str": 2,
-        "no-multiple-empty-lines": 2,
+        "no-multiple-empty-lines": [2, {"max": 1, "maxEOF": 0}],
         "no-native-reassign": 2,
         "no-negated-in-lhs": 2,
         "no-new-object": 2,


### PR DESCRIPTION
This is a small part of https://github.com/magento/magento-coding-standard/pull/347 as suggested in https://github.com/magento/magento-coding-standard/pull/347#issuecomment-999512251.

https://eslint.org/docs/rules/no-multiple-empty-lines