### PR TITLE
[eslint] Disallow useless constructs

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -81,6 +81,12 @@
             }
         ],
         "no-use-before-define": 2,
+        "no-useless-call": 2,
+        "no-useless-computed-key": 2,
+        "no-useless-constructor": 2,
+        "no-useless-escape": 2,
+        "no-useless-rename": 2,
+        "no-useless-return": 2,
         "no-with": 2,
         "one-var": [2, "always"],
         "operator-assignment": [2, "always"],


### PR DESCRIPTION
This is a small part of https://github.com/magento/magento-coding-standard/pull/347 as suggested in https://github.com/magento/magento-coding-standard/pull/347#issuecomment-999512251.

https://eslint.org/docs/rules/no-useless-call
https://eslint.org/docs/rules/no-useless-computed-key
https://eslint.org/docs/rules/no-useless-constructor
https://eslint.org/docs/rules/no-useless-escape
https://eslint.org/docs/rules/no-useless-rename
https://eslint.org/docs/rules/no-useless-return