### PR TITLE
AC-1895: Avoid having duplicated issues in magento-coding-standard

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -164,6 +164,10 @@
         <severity>10</severity>
         <type>error</type>
     </rule>
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions">
+        <severity>10</severity>
+        <type>error</type>
+    </rule>
     <!-- Severity 9 warnings: Possible security and issues that may cause bugs. -->
     <rule ref="Generic.Files.ByteOrderMark">
         <severity>9</severity>
@@ -761,8 +765,7 @@
         <exclude name="PHPCompatibility.Constants.NewMagicClassConstant.Found" />
         <exclude name="PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods.Found" />
         <!-- Following sniffs have an equivalent in PHPCS -->
-        <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference.Deprecated" />
-        <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference.NotAllowed" />
+        <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference" />
         <!-- Check for cross-version support for stated PHP version and higher. -->
         <config name="testVersion" value="7.4-"/>
     </rule>

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -16,11 +16,6 @@
         <exclude-pattern>*\.phtml$</exclude-pattern>
         <exclude-pattern>*\.xml$</exclude-pattern>
     </rule>
-    <rule ref="Generic.PHP.DeprecatedFunctions">
-        <severity>10</severity>
-        <type>error</type>
-        <exclude-pattern>*\.xml$</exclude-pattern>
-    </rule>
     <rule ref="Generic.PHP.NoSilencedErrors">
         <severity>10</severity>
         <type>error</type>
@@ -762,9 +757,12 @@
     </rule>
     <rule ref="PHPCompatibility">
         <exclude name="PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound" />
-        <!-- Following sniffs has been updated or renamed in PHPCompatibility 10 -->
-        <exclude name="PHPCompatibility.Constants.NewMagicClassConstant" />
-        <exclude name="PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods" />
+        <!-- Following sniffs have been updated or renamed in PHPCompatibility 10 -->
+        <exclude name="PHPCompatibility.Constants.NewMagicClassConstant.Found" />
+        <exclude name="PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods.Found" />
+        <!-- Following sniffs have an equivalent in PHPCS -->
+        <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference.Deprecated" />
+        <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference.NotAllowed" />
         <!-- Check for cross-version support for stated PHP version and higher. -->
         <config name="testVersion" value="7.4-"/>
     </rule>


### PR DESCRIPTION
There are a couple of sniffs duplicated between PHPCS and PHP Compatibility. I've picked the ones with better coverage after doing some tests.

| Excluded | Kept | Description |
| --- | --- | --- |
| Generic.PHP.DeprecatedFunctions | PHPCompatibility.FunctionUse.RemovedFunctions | Excluded one only catches deprecations and, due to it using `get_defined_functions()` to get deprecated methods, it doesn't include functions coming from extensions or deprecations from different PHP versions than the one which is running the sniff. |
| PHPCompatibility.Syntax.ForbiddenCallTimePassByReference | Generic.Functions.CallTimePassByReference | Both are equivalent, there is no special advantage of one over the other; in fact, call-time pass-by-reference is forbidden since PHP 5.4 so we can remove both checks. |