### PR TITLE
Allow Use of Template Literals

### DIFF
--- a/eslint/.eslintrc-magento
+++ b/eslint/.eslintrc-magento
@@ -84,7 +84,7 @@
         "no-with": 2,
         "one-var": [2, "always"],
         "operator-assignment": [2, "always"],
-        "quotes": [2, "single"],
+        "quotes": [2, "single", {"allowTemplateLiterals": true}],
         "radix": 2,
         "semi": [2, "always"],
         "semi-spacing": 2,


### PR DESCRIPTION
https://eslint.org/docs/rules/quotes

We shouldn't deter people from making code more readable.

### Resolved issues:
1. [x] resolves magento/magento-coding-standard#403: Allow Use of Template Literals