### PR TITLE
AC-1895: Exclude sniff that is duplicated

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -766,6 +766,7 @@
         <exclude name="PHPCompatibility.Classes.ForbiddenAbstractPrivateMethods.Found" />
         <!-- Following sniffs have an equivalent in PHPCS -->
         <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference" />
+        <exclude name="PHPCompatibility.Keywords.ForbiddenNamesAsDeclared" />
         <!-- Check for cross-version support for stated PHP version and higher. -->
         <config name="testVersion" value="7.4-"/>
     </rule>


### PR DESCRIPTION
| Excluded | Kept | Description |
| --------- | ----- | ----------- |
| PHPCompatibility.Keywords.ForbiddenNamesAsDeclared | Magento2.NamingConvention.ReservedWords | Both are equivalent. ReservedWords is customised for Magento2, so I think this is easier to extend it, if needed in the future |