### PR TITLE
PHP 8.1 Compatibility

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -761,9 +761,13 @@
         <exclude-pattern>*Test.php</exclude-pattern>
         <exclude-pattern>*/PHPCSUtils/*</exclude-pattern>
     </rule>
+
     <rule ref="Internal.NoCodeFound">
         <severity>0</severity>
     </rule>
+
+    <!-- PHPCompatibility configuration. -->
+    <config name="testVersion" value="7.4-"/>
     <rule ref="PHPCompatibility">
         <exclude name="PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound" />
         <!-- Following sniffs have been updated or renamed in PHPCompatibility 10 -->
@@ -772,8 +776,6 @@
         <!-- Following sniffs have an equivalent in PHPCS -->
         <exclude name="PHPCompatibility.Syntax.ForbiddenCallTimePassByReference" />
         <exclude name="PHPCompatibility.Keywords.ForbiddenNamesAsDeclared" />
-        <!-- Check for cross-version support for stated PHP version and higher. -->
-        <config name="testVersion" value="7.4-"/>
     </rule>
     <!--
      All these rules belong to the unreleased PhpCompatibility 10. Remove them once PHPCompatibility is


### PR DESCRIPTION
Preventing the error appearing on PHP 8.1:

```
------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted. The error message was: trim(): Passing null to parameter #1 ($string) of
   |       | type string is deprecated in
   |       | /Users/sivashch/Projects/magento-coding-standard/vendor/phpcompatibility/php-compatibility/PHPCompatibility/Sniff.php on line 131
------------------------------------------------------------------------------------------------------------------------------------------------------
```

Test builds sensitivity improved in https://github.com/magento/magento-coding-standard/pull/367

Fixes https://jira.corp.magento.com/browse/AC-2349