### PR TITLE
Autofix for ThisInTemplate sniff

### DIFF
--- a/Magento2/Tests/Templates/ThisInTemplateUnitTest.inc.fixed
+++ b/Magento2/Tests/Templates/ThisInTemplateUnitTest.inc.fixed
@@ -1,0 +1,5 @@
+<?php
+echo $block->escapeHtml($block->getGroupCode());
+echo $block->escapeHtml($block->getGroupCode());
+$block->foo();
+$block->helper();

--- a/Magento2/Tests/Templates/ThisInTemplateUnitTest.php
+++ b/Magento2/Tests/Templates/ThisInTemplateUnitTest.php
@@ -25,7 +25,7 @@ class ThisInTemplateUnitTest extends AbstractSniffUnitTest
         return [
             3 => 2,
             4 => 1,
-            5 => 1,
+            5 => 2,
         ];
     }
 }


### PR DESCRIPTION
Covered ThisInTemplateSniff with autofix. Autofix is replacing `$this` with `$block` in `.phtml` files


Autofixes are applied when executing `vendor/bin/phpcbf` instead of `vendor/bin/phpcs` (preserving most options/arguments).

Also, corrected helper call check: this test does not replace the original warning, but adds an additional one.

Resolves: https://jira.corp.magento.com/browse/AC-2221