### PR TITLE
AC-2222: [UCT Autofixing] PHPCompatibility.ForbiddenFinalPrivateMethods

### DIFF
--- a/Magento2/Sniffs/PHPCompatibility/ForbiddenFinalPrivateMethodsSniff.php
+++ b/Magento2/Sniffs/PHPCompatibility/ForbiddenFinalPrivateMethodsSniff.php
@@ -83,7 +83,7 @@ class ForbiddenFinalPrivateMethodsSniff extends Sniff
             // Not a private final method.
             return;
         }
-        $phpcsFile->fixer->enabled = true;
+
         if ($phpcsFile->addFixableWarning(self::MESSAGE_FINAL, $stackPtr, 'Found') === true) {
             $phpcsFile->fixer->beginChangeset();
             $prev = $phpcsFile->findPrevious(\T_FINAL, ($stackPtr - 1));

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -1,21 +1,27 @@
 <?php
 
-class CrossVersionInValid
+final class CrossVersionInValid
 {
     private final function __construct() {}
     final private function privateFinal();
     static private final function privateStaticFinal();
+    static protected final function protectedStaticFinal();
+    final protected function protectedFinal();
 }
 
 $anon = new class() {
     private final function __construct() {}
     final private function privateFinal();
     static final private function privateStaticFinal();
+    final protected function protectedFinal();
+    static final protected function protectedStaticFinal();
 };
 
 trait CrossVersionInValidTrait
 {
     private final function __construct() {}
     final private function privateFinal();
+    final protected function protectedFinal();
     static private final function privateStaticFinal();
+    static protected final function protectedStaticFinal();
 }

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc
@@ -1,47 +1,21 @@
 <?php
 
-/*
- * OK cross version.
- */
-class CrossVersionValid
-{
-    private final function __construct() {}
-    final public function publicFinal() {}
-    final protected static function protectedFinal() {}
-    private function privateNonOverloadable() {}
-}
-
-trait CrossVersionValidTrait
-{
-    final private function __CONSTRUCT() {}
-    final public static function publicFinal() {}
-    final protected function protectedFinal() {}
-    private function privateStillOverloadable() {} // Open question in RFC PR https://github.com/php/php-src/pull/5401
-}
-
-$anon = new class() {
-    final private function __Construct() {}
-    final public static function publicFinal();
-    final protected function protectedFinal();
-    private function privateNonOverloadable() {}
-};
-
-/*
- * PHP 8.0: private methods cannot be final as they are never overridden by other classes.
- */
 class CrossVersionInValid
 {
+    private final function __construct() {}
     final private function privateFinal();
     static private final function privateStaticFinal();
 }
 
 $anon = new class() {
+    private final function __construct() {}
     final private function privateFinal();
     static final private function privateStaticFinal();
 };
 
 trait CrossVersionInValidTrait
 {
+    private final function __construct() {}
     final private function privateFinal();
     static private final function privateStaticFinal();
 }

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc.fixed
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc.fixed
@@ -1,21 +1,27 @@
 <?php
 
-class CrossVersionInValid
+final class CrossVersionInValid
 {
     private final function __construct() {}
     private function privateFinal();
     static private function privateStaticFinal();
+    static protected final function protectedStaticFinal();
+    final protected function protectedFinal();
 }
 
 $anon = new class() {
     private final function __construct() {}
     private function privateFinal();
     static private function privateStaticFinal();
+    final protected function protectedFinal();
+    static final protected function protectedStaticFinal();
 };
 
 trait CrossVersionInValidTrait
 {
     private final function __construct() {}
     private function privateFinal();
+    final protected function protectedFinal();
     static private function privateStaticFinal();
+    static protected final function protectedStaticFinal();
 }

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc.fixed
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.inc.fixed
@@ -1,0 +1,21 @@
+<?php
+
+class CrossVersionInValid
+{
+    private final function __construct() {}
+    private function privateFinal();
+    static private function privateStaticFinal();
+}
+
+$anon = new class() {
+    private final function __construct() {}
+    private function privateFinal();
+    static private function privateStaticFinal();
+};
+
+trait CrossVersionInValidTrait
+{
+    private final function __construct() {}
+    private function privateFinal();
+    static private function privateStaticFinal();
+}

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -10,6 +10,8 @@
 
 namespace Magento2\Tests\PHPCompatibility;
 
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Test the ForbiddenFinalPrivateMethods sniff.
  *
@@ -20,84 +22,28 @@ namespace Magento2\Tests\PHPCompatibility;
  *
  * @since 10.0.0
  */
-class ForbiddenFinalPrivateMethodsUnitTest extends BaseSniffTest
+class ForbiddenFinalPrivateMethodsUnitTest extends AbstractSniffUnitTest
 {
-
     /**
-     * Verify that the sniff throws a warning for non-construct final private methods for PHP 8.0+.
-     *
-     * @dataProvider dataForbiddenFinalPrivateMethods
-     *
-     * @param int $line The line number where a warning is expected.
-     *
-     * @return void
+     * @inheritdoc
      */
-    public function testForbiddenFinalPrivateMethods($line)
+    public function getErrorList()
     {
-        $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertWarning($file, $line, 'Private methods should not be declared as final since PHP 8.0');
+        return [];
     }
 
     /**
-     * Data provider.
-     *
-     * @see testForbiddenFinalPrivateMethods()
-     *
-     * @return array
+     * @inheritdoc
      */
-    public function dataForbiddenFinalPrivateMethods()
+    public function getWarningList()
     {
-        return [
-            [34],
-            [35],
-            [39],
-            [40],
-            [45],
-            [46],
+       return [
+            6 => 1,
+            7 => 1,
+            12 => 1,
+            13 => 1,
+            19 => 1,
+            20 => 1,
         ];
-    }
-
-    /**
-     * Verify the sniff does not throw false positives for valid code.
-     *
-     * @dataProvider dataNoFalsePositives
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testNoFalsePositives($line)
-    {
-        $file = $this->sniffFile(__FILE__, '8.0');
-        $this->assertNoViolation($file, $line);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testNoFalsePositives()
-     *
-     * @return array
-     */
-    public function dataNoFalsePositives()
-    {
-        $cases = [];
-        // No errors expected on the first 28 lines.
-        for ($line = 1; $line <= 28; $line++) {
-            $cases[] = [$line];
-        }
-
-        return $cases;
-    }
-
-    /**
-     * Verify no notices are thrown at all.
-     *
-     * @return void
-     */
-    public function testNoViolationsInFileOnValidVersion()
-    {
-        $file = $this->sniffFile(__FILE__, '7.4');
-        $this->assertNoViolation($file);
     }
 }

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -40,10 +40,10 @@ class ForbiddenFinalPrivateMethodsUnitTest extends AbstractSniffUnitTest
        return [
             6 => 1,
             7 => 1,
-            12 => 1,
-            13 => 1,
-            19 => 1,
-            20 => 1,
+            14 => 1,
+            15 => 1,
+            23 => 1,
+            25 => 1,
         ];
     }
 }


### PR DESCRIPTION
This code will autofix occurrences of `final private` methods which actually make no sense.
Note that original test code was customised for PHPCompatibility and didn't support autofix checking, so I had to adapt it to PHPCS unit tests-style. Also, warning was only issued if code had to be compatible with PHP 8. 