### PR TITLE
AC-2219: Magento2.Functions.FunctionsDeprecatedWithoutArgument

### DIFF
--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -36,7 +36,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
      * @var array
      */
     private const DEPRECATED_FUNCTIONS_AND_FIXES = [
-        'mb_check_encoding' => 'null',
+        'mb_check_encoding' => '\'\'',
         'get_class' => '$this',
         'get_parent_class' => '$this'
     ];

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -77,12 +77,14 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
             );
             return;
         }
+        
+        $fix = $phpcsFile->addFixableWarning(
+            sprintf(self::WARNING_MESSAGE, $functionName),
+            $stackPtr,
+            self::WARNING_CODE
+        );
 
-        if ($phpcsFile->addFixableWarning(
-                sprintf(self::WARNING_MESSAGE, $functionName),
-                $stackPtr,
-                self::WARNING_CODE
-            ) === true) {
+        if ($fix === true) {
             $content = self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName];
             $phpcsFile->fixer->beginChangeset();
             $phpcsFile->fixer->addContentBefore($phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr), $content);

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -36,7 +36,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
      * @var array
      */
     private const DEPRECATED_FUNCTIONS_AND_FIXES = [
-        'mb_check_encoding' => '[]',
+        'mb_check_encoding' => 'STDIN',
         'get_class' => '$this',
         'get_parent_class' => '$this'
     ];

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -31,15 +31,15 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
     private const WARNING_CODE = 'FunctionsDeprecatedWithoutArgument';
 
     /**
-     * Deprecated functions without argument.
+     * Deprecated functions without argument
      *
      * @var array
      */
-    private const FUNCTIONS_LIST = [
-        'mb_check_encoding',
-        'get_class',
-        'get_parent_class',
-        'get_called_class'
+    private const DEPRECATED_FUNCTIONS_AND_FIXES = [
+        'mb_check_encoding' => 'null',
+        'get_class' => '$this',
+        'get_parent_class' => '$this',
+        'get_called_class' => '$this'
     ];
 
     /**
@@ -66,8 +66,17 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
 
         $functionName = $phpcsFile->getTokensAsString($phpcsFile->findPrevious(T_STRING, $stackPtr), 1);
 
-        if (in_array($functionName, self::FUNCTIONS_LIST)) {
-            $phpcsFile->addWarning(sprintf(self::WARNING_MESSAGE, $functionName), $stackPtr, self::WARNING_CODE);
+        if (in_array($functionName, array_keys(self::DEPRECATED_FUNCTIONS_AND_FIXES))) {
+            if ($phpcsFile->addFixableWarning(
+                sprintf(self::WARNING_MESSAGE, $functionName),
+                $stackPtr,
+                self::WARNING_CODE
+            ) === true) {
+                $content = self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName];
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addContentBefore($phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr), $content);
+                $phpcsFile->fixer->endChangeset();
+            }
         }
     }
 }

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -38,8 +38,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
     private const DEPRECATED_FUNCTIONS_AND_FIXES = [
         'mb_check_encoding' => 'null',
         'get_class' => '$this',
-        'get_parent_class' => '$this',
-        'get_called_class' => '$this'
+        'get_parent_class' => '$this'
     ];
 
     /**

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -36,7 +36,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
      * @var array
      */
     private const DEPRECATED_FUNCTIONS_AND_FIXES = [
-        'mb_check_encoding' => '\'\'',
+        'mb_check_encoding' => '[]',
         'get_class' => '$this',
         'get_parent_class' => '$this'
     ];

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -75,6 +75,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
                 $stackPtr,
                 self::WARNING_CODE
             );
+            return;
         }
 
         if ($phpcsFile->addFixableWarning(

--- a/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
+++ b/Magento2/Sniffs/Functions/FunctionsDeprecatedWithoutArgumentSniff.php
@@ -36,7 +36,7 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
      * @var array
      */
     private const DEPRECATED_FUNCTIONS_AND_FIXES = [
-        'mb_check_encoding' => 'STDIN',
+        'mb_check_encoding' => false,
         'get_class' => '$this',
         'get_parent_class' => '$this'
     ];
@@ -65,17 +65,27 @@ class FunctionsDeprecatedWithoutArgumentSniff implements Sniff
 
         $functionName = $phpcsFile->getTokensAsString($phpcsFile->findPrevious(T_STRING, $stackPtr), 1);
 
-        if (in_array($functionName, array_keys(self::DEPRECATED_FUNCTIONS_AND_FIXES))) {
-            if ($phpcsFile->addFixableWarning(
+        if (!isset(self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName])) {
+            return;
+        }
+
+        if (self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName] === false) {
+            $phpcsFile->addWarning(
+                sprintf(self::WARNING_MESSAGE, $functionName),
+                $stackPtr,
+                self::WARNING_CODE
+            );
+        }
+
+        if ($phpcsFile->addFixableWarning(
                 sprintf(self::WARNING_MESSAGE, $functionName),
                 $stackPtr,
                 self::WARNING_CODE
             ) === true) {
-                $content = self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName];
-                $phpcsFile->fixer->beginChangeset();
-                $phpcsFile->fixer->addContentBefore($phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr), $content);
-                $phpcsFile->fixer->endChangeset();
-            }
+            $content = self::DEPRECATED_FUNCTIONS_AND_FIXES[$functionName];
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->addContentBefore($phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr), $content);
+            $phpcsFile->fixer->endChangeset();
         }
     }
 }

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc
@@ -25,9 +25,7 @@ class FunctionsDeprecatedWithoutArgument
             get_class(), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),
             get_parent_class(), // Calling without argument is deprecated.
-            get_parent_class('test-argument'),
-            get_called_class(), // Calling without argument is deprecated.
-            get_called_class('test-argument')
+            get_parent_class('test-argument')
         ];
     }
 }

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc
@@ -21,11 +21,11 @@ class FunctionsDeprecatedWithoutArgument
     {
         return [
             mb_check_encoding(), // Calling without argument is deprecated.
-            mb_check_encoding('test-argument', null),
+            mb_check_encoding('test-argument'),
             get_class(), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),
             get_parent_class(), // Calling without argument is deprecated.
-            get_parent_class('test-argument')
+            get_parent_class(new FunctionsDeprecatedWithoutArgument())
         ];
     }
 }

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -20,7 +20,7 @@ class FunctionsDeprecatedWithoutArgument
     public function testDeprecatedMethod(): array
     {
         return [
-            mb_check_encoding(null), // Calling without argument is deprecated.
+            mb_check_encoding(''), // Calling without argument is deprecated.
             mb_check_encoding('test-argument', null),
             get_class($this), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -25,9 +25,7 @@ class FunctionsDeprecatedWithoutArgument
             get_class($this), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),
             get_parent_class($this), // Calling without argument is deprecated.
-            get_parent_class('test-argument'),
-            get_called_class($this), // Calling without argument is deprecated.
-            get_called_class('test-argument')
+            get_parent_class('test-argument')
         ];
     }
 }

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -20,7 +20,7 @@ class FunctionsDeprecatedWithoutArgument
     public function testDeprecatedMethod(): array
     {
         return [
-            mb_check_encoding([]), // Calling without argument is deprecated.
+            mb_check_encoding(STDIN), // Calling without argument is deprecated.
             mb_check_encoding('test-argument'),
             get_class($this), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -20,12 +20,12 @@ class FunctionsDeprecatedWithoutArgument
     public function testDeprecatedMethod(): array
     {
         return [
-            mb_check_encoding(''), // Calling without argument is deprecated.
-            mb_check_encoding('test-argument', null),
+            mb_check_encoding([]), // Calling without argument is deprecated.
+            mb_check_encoding('test-argument'),
             get_class($this), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),
             get_parent_class($this), // Calling without argument is deprecated.
-            get_parent_class('test-argument')
+            get_parent_class(new FunctionsDeprecatedWithoutArgument())
         ];
     }
 }

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento2\Tests\Functions;
+
+/**
+ * Class to test validate PHP functions usage of which without passing arguments.
+ */
+class FunctionsDeprecatedWithoutArgument
+{
+    /**
+     * Test deprecation function.
+     *
+     * @return array
+     */
+    public function testDeprecatedMethod(): array
+    {
+        return [
+            mb_check_encoding(null), // Calling without argument is deprecated.
+            mb_check_encoding('test-argument', null),
+            get_class($this), // Calling without argument is deprecated.
+            get_class(new FunctionsDeprecatedWithoutArgument()),
+            get_parent_class($this), // Calling without argument is deprecated.
+            get_parent_class('test-argument'),
+            get_called_class($this), // Calling without argument is deprecated.
+            get_called_class('test-argument')
+        ];
+    }
+}

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.inc.fixed
@@ -20,7 +20,7 @@ class FunctionsDeprecatedWithoutArgument
     public function testDeprecatedMethod(): array
     {
         return [
-            mb_check_encoding(STDIN), // Calling without argument is deprecated.
+            mb_check_encoding(), // Calling without argument is deprecated.
             mb_check_encoding('test-argument'),
             get_class($this), // Calling without argument is deprecated.
             get_class(new FunctionsDeprecatedWithoutArgument()),

--- a/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.php
+++ b/Magento2/Tests/Functions/FunctionsDeprecatedWithoutArgumentUnitTest.php
@@ -30,8 +30,7 @@ class FunctionsDeprecatedWithoutArgumentUnitTest extends AbstractSniffUnitTest
         return [
             23 => 1,
             25 => 1,
-            27 => 1,
-            29 => 1
+            27 => 1
         ];
     }
 }


### PR DESCRIPTION
https://jira.corp.magento.com/browse/AC-2219 Magento2.Functions.FunctionsDeprecatedWithoutArgument