### PR TITLE
Resolve incorrect violation code in `Magento2.Security.XssTemplate` sniff

### DIFF
--- a/Magento2/Sniffs/Security/XssTemplateSniff.php
+++ b/Magento2/Sniffs/Security/XssTemplateSniff.php
@@ -135,6 +135,7 @@ class XssTemplateSniff implements Sniff
             $statement = array_shift($this->statements);
             $this->detectUnescapedString($statement);
         }
+        $this->hasDisallowedAnnotation = false;
     }
 
     /**


### PR DESCRIPTION
This PR resolves the issue that in the `Magento2.Security.XssTemplate` sniff `FoundUnescaped` violations are sometimes incorrectly reported as `FoundNotAllowed`.

This currently happens from the moment the first `FoundNotAllowed` is reported, after that all violations are reported as `FoundNotAllowed`.

Consider the following code:

```phtml
<?= /* @disallowedAnnotation */ $foo ?>
<?= $bar ?>
```

The following is reported (the second warning has the wrong code):

```
FILE: /path/to/file.phtml
------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
------------------------------------------------------------------------------------------
 1 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundNotAllowed)
 2 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundNotAllowed)
------------------------------------------------------------------------------------------
```

This PR makes sure the following is reported:

```
FILE: /path/to/file.phtml
------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
------------------------------------------------------------------------------------------
 1 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundNotAllowed)
 2 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundUnescaped)
------------------------------------------------------------------------------------------
```

This is done by resetting the `hasDisallowedAnnotation` property at then end of processing.