### PR TITLE
Add semicolon as statement separator in the special annotation check of the `Magento2.Security.XssTemplate` sniff

### DIFF
--- a/Magento2/Sniffs/Security/XssTemplateSniff.php
+++ b/Magento2/Sniffs/Security/XssTemplateSniff.php
@@ -146,11 +146,11 @@ class XssTemplateSniff implements Sniff
     private function findSpecialAnnotation($stackPtr)
     {
         if ($this->tokens[$stackPtr]['code'] === T_ECHO) {
-            $startOfStatement = $this->file->findPrevious(T_OPEN_TAG, $stackPtr);
+            $startOfStatement = $this->file->findPrevious([T_OPEN_TAG, T_SEMICOLON], $stackPtr);
             return $this->file->findPrevious(T_COMMENT, $stackPtr, $startOfStatement);
         }
         if ($this->tokens[$stackPtr]['code'] === T_OPEN_TAG_WITH_ECHO) {
-            $endOfStatement = $this->file->findNext(T_CLOSE_TAG, $stackPtr);
+            $endOfStatement = $this->file->findNext([T_CLOSE_TAG, T_SEMICOLON], $stackPtr);
             return $this->file->findNext(T_COMMENT, $stackPtr, $endOfStatement);
         }
         return false;


### PR DESCRIPTION
This PR improves special annotation detection of the `Magento2.Security.XssTemplate` sniff by adding `T_SEMICOLON` as a statement separator. This resolves the issue that violations in a statement might be ignored by a special annotation in a previous/subsequent statement.

For example, consider the following file:

```phtml
<?php
    /* @noEscape */ echo $foo;
    echo $bar;
?>
<?=
    $baz;
    /* @noEscape */ echo $qux;
?>
```

This does not reported any violations of the `Magento2.Security.XssTemplate` sniff.

However, the statements involving `$bar` and `$baz` should report a `FoundUnescaped` violation.

This PR makes sure this is done, such that the following is reported:

```
FILE: /path/to/file.phtml
-----------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------
 3 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundUnescaped)
 6 | WARNING | Unescaped output detected.
   |         | (Magento2.Security.XssTemplate.FoundUnescaped)
-----------------------------------------------------------------------------------------
```