### PR TITLE
Add `@author` to forbidden tag list

### DIFF
--- a/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
@@ -24,6 +24,7 @@ class ClassAndInterfacePHPDocFormattingSniff implements Sniff
      * @var string[] List of tags that can not be used in comments
      */
     public $forbiddenTags = [
+        '@author',
         '@category',
         '@package',
         '@subpackage'

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -60,9 +60,9 @@ class EmptyHandler
  * @api is ok here
  * @deprecated can be used in this context
  * @see is ok here
- * @author is not ment to be used
+ * @author should not be used
  * @category is irrelevant
- * @package is not ment to be used
+ * @package should not be used
  * @subpackage does not belong here
  */
 class ExampleHandler

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -60,7 +60,7 @@ class EmptyHandler
  * @api is ok here
  * @deprecated can be used in this context
  * @see is ok here
- * @author is actually ok
+ * @author is not ment to be used
  * @category is irrelevant
  * @package is not ment to be used
  * @subpackage does not belong here

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
@@ -60,9 +60,9 @@ interface EmptyHandler
  * @api is ok here
  * @deprecated can be used in this context
  * @see is ok here
- * @author is not ment to be used
+ * @author should not be used
  * @category is irrelevant
- * @package is not ment to be used
+ * @package should not be used
  * @subpackage does not belong here
  */
 interface ExampleHandler

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
@@ -60,7 +60,7 @@ interface EmptyHandler
  * @api is ok here
  * @deprecated can be used in this context
  * @see is ok here
- * @author is actually ok
+ * @author is not ment to be used
  * @category is irrelevant
  * @package is not ment to be used
  * @subpackage does not belong here

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
@@ -29,6 +29,7 @@ class ClassAndInterfacePHPDocFormattingUnitTest extends AbstractSniffUnitTest
             35 => 1,
             44 => 1,
             52 => 1,
+            63 => 1,
             64 => 1,
             65 => 1,
             66 => 1,


### PR DESCRIPTION
Ref https://devdocs.magento.com/guides/v2.4/coding-standards/docblock-standard-general.html#documentation-space
Fixes #167