### PR TITLE
Fix warnings detected by phpcs & phpunit

### DIFF
--- a/Magento2/Tests/PHPCompatibility/BaseSniffTest.php
+++ b/Magento2/Tests/PHPCompatibility/BaseSniffTest.php
@@ -29,7 +29,7 @@ use Magento2\Helpers\PHPCSUtils\BackCompat\Helper;
  * @since 9.0.0  Dropped support for PHP_CodeSniffer 1.x.
  * @since 10.0.0 Updated for preliminary support of PHP_CodeSniffer 4.
  */
-class BaseSniffTest extends TestCase
+abstract class BaseSniffTest extends TestCase
 {
 
     /**

--- a/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
+++ b/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
@@ -37,7 +37,7 @@ class ForbiddenFinalPrivateMethodsUnitTest extends AbstractSniffUnitTest
      */
     public function getWarningList()
     {
-       return [
+        return [
             6 => 1,
             7 => 1,
             14 => 1,


### PR DESCRIPTION
While working on another change, I followed the [instructions in the README](https://github.com/magento/magento-coding-standard/blob/470f7a62b2433b0208eebaa6984af86c04736260/README.md#testing) which say to run `vendor/bin/phpunit && vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php`. These reported errors which were unrelated to the changes I was making. This pull request solves those errors.

For reference, the output of the above commands used to be:
```sh
app@8a43352ec6d2:~/html$ vendor/bin/phpunit && vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php
PHPUnit 9.5.20 #StandWithUkraine

...........................................W...................  63 / 204 ( 30%)
............................................................... 126 / 204 ( 61%)
....................................S.......................... 189 / 204 ( 92%)
...............                                                 204 / 204 (100%)

Time: 00:06.970, Memory: 134.50 MB

There was 1 warning:

1) Warning
No tests found in class "Magento2\Tests\PHPCompatibility\BaseSniffTest".

phpvfscomposer:///var/www/html/vendor/phpunit/phpunit/phpunit:97

WARNINGS!
Tests: 204, Assertions: 160, Warnings: 1, Skipped: 1.

FILE: /var/www/html/Magento2/Tests/PHPCompatibility/ForbiddenFinalPrivateMethodsUnitTest.php
--------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------
 40 | WARNING | [x] Line indented incorrectly; expected at least 8 spaces, found 7
--------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------------------

Time: 6.76 secs; Memory: 22MB

app@8a43352ec6d2:~/html$ 
```
and is now
```sh
app@8a43352ec6d2:~/html$ vendor/bin/phpunit && vendor/bin/phpcs --standard=Magento2 Magento2/ --extensions=php
PHPUnit 9.5.20 #StandWithUkraine

...............................................................  63 / 203 ( 31%)
............................................................... 126 / 203 ( 62%)
...................................S........................... 189 / 203 ( 93%)
..............                                                  203 / 203 (100%)

Time: 00:06.908, Memory: 134.50 MB

OK, but incomplete, skipped, or risky tests!
Tests: 203, Assertions: 160, Skipped: 1.
app@8a43352ec6d2:~/html$ 
```