### PR TITLE
Allow empty constructor function blocks when using property promotion

### DIFF
--- a/Magento2/Sniffs/CodeAnalysis/EmptyBlockSniff.php
+++ b/Magento2/Sniffs/CodeAnalysis/EmptyBlockSniff.php
@@ -37,6 +37,17 @@ class EmptyBlockSniff extends EmptyStatementSniff
             return;
         }
 
+        // Ignore empty constructor function blocks when using property promotion
+        if ($tokens[$stackPtr]['code'] === T_FUNCTION &&
+            strpos($phpcsFile->getDeclarationName($stackPtr), '__construct') === 0 &&
+            count($phpcsFile->getMethodParameters($stackPtr)) > 0 &&
+            array_reduce($phpcsFile->getMethodParameters($stackPtr), static function ($result, $methodParam) {
+                return $result && isset($methodParam['property_visibility']);
+            }, true)) {
+
+            return;
+        }
+
         parent::process($phpcsFile, $stackPtr);
     }//end process()
 }

--- a/Magento2/Tests/CodeAnalysis/EmptyBlockUnitTest.inc
+++ b/Magento2/Tests/CodeAnalysis/EmptyBlockUnitTest.inc
@@ -76,3 +76,15 @@ function emptyFunction () { /*Empty function block*/ }
 function nonEmptyFunction () { return true; }
 
 function aroundEmptyFunction ($foo, $bar) { }
+
+class Foo {
+    public function __construct(private $bar) {}
+}
+
+class Foo2 {
+    public function __construct() {}
+}
+
+class Foo3 {
+    public function __construct(private $bar, $baz) {}
+}

--- a/Magento2/Tests/CodeAnalysis/EmptyBlockUnitTest.php
+++ b/Magento2/Tests/CodeAnalysis/EmptyBlockUnitTest.php
@@ -29,6 +29,8 @@ class EmptyBlockUnitTest extends AbstractSniffUnitTest
             68 => 1,
             72 => 2,
             74 => 1,
+            85 => 1,
+            89 => 1
         ];
     }
 


### PR DESCRIPTION
This fixes #385 

This PR introduces an additional exception to the EmptyBlock rule. Empty constructor function blocks will no longer result in errors in case there is at least one parameter and every parameter has a visibility set.

This improves the coding standard, as it allows the use of the new PHP 8.0 feature of property promotion. For constructors where every single parameter is promoted, an empty function block is expected and does not represent a code smell.