### PR TITLE
AC-3098: Update hasDeprecatedWellFormatted

### DIFF
--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -121,15 +121,11 @@ class PHPDocFormattingValidator
         if ($deprecatedPtr === -1) {
             return true;
         }
-
-        $seeTagRequired = false;
-        if ($tokens[$deprecatedPtr + 2]['code'] !== T_DOC_COMMENT_STRING) {
-            $seeTagRequired = true;
-        }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            return !$seeTagRequired;
+            return false;
         }
+
         return $tokens[$seePtr + 2]['code'] === T_DOC_COMMENT_STRING;
     }
 

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
@@ -33,6 +33,7 @@ class ClassAndInterfacePHPDocFormattingUnitTest extends AbstractSniffUnitTest
             65 => 1,
             66 => 1,
             101 => 1,
+            109 => 1,
             118 => 1,
             127 => 1,
         ];

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.1.inc
@@ -8,11 +8,6 @@ define('DS', DIRECTORY_SEPARATOR);
 define('BP', dirname(__FILE__));
 
 /**
- * @deprecated It is a lie
- */
-define('THERE IS', 'cake');
-
-/**
  * @deprecated New implementation available
  * @see \Ascii\Asterisk
  */
@@ -26,11 +21,6 @@ class Profiler
      * Unlike first const, this one is not self explanatory.
      */
     const NUMBER_TWO = 2;
-
-    /**
-     * @deprecated Why not
-     */
-    const YES = false;
 
     /**
      * @deprecated Unable to identify the question, replaced

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
@@ -14,6 +14,11 @@ define('NUMBER_ONE', 1);
 define('A', 65);
 
 /**
+ * @deprecated It is a lie
+ */
+define('THERE IS', 'cake');
+
+/**
  * @deprecated
  * @see
  */
@@ -41,6 +46,11 @@ class Profiler
      * @deprecated
      */
     const a = 97;
+
+    /**
+     * @deprecated Why not
+     */
+    const YES = false;
 
     /**
      * @deprecated

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.php
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.php
@@ -30,13 +30,15 @@ class ConstantsPHPDocFormattingUnitTest extends AbstractSniffUnitTest
             6 => 1,
             9 => 1,
             14 => 1,
-            20 => 1,
-            26 => 1,
-            33 => 1,
+            19 => 1,
+            25 => 1,
+            31 => 1,
             38 => 1,
             43 => 1,
-            49 => 1,
-            55 => 1
+            48 => 1,
+            53 => 1,
+            59 => 1,
+            65 => 1
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "phpcompatibility/php-compatibility": "^9.3",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "rector/rector": "^0.12.17"
+        "rector/rector": "^0.13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63d0aa40cf8f2071a5e7e572eae08f45",
+    "content-hash": "a3c03834eb0c721e9899cf1377029d57",
     "packages": [
         {
             "name": "phpcompatibility/php-compatibility",
@@ -70,16 +70,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.5.7",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac"
+                "reference": "e3baed2ee2ef322e0f9b8fe8f87fdbe024c7c719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
-                "reference": "7fb7e2e1e9f3d59a26a413b2d3d5e47f0edb75ac",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e3baed2ee2ef322e0f9b8fe8f87fdbe024c7c719",
+                "reference": "e3baed2ee2ef322e0f9b8fe8f87fdbe024c7c719",
                 "shasum": ""
             },
             "require": {
@@ -105,7 +105,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.5.7"
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.1"
             },
             "funding": [
                 {
@@ -125,25 +125,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-20T12:20:27+00:00"
+            "time": "2022-05-24T09:05:09+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.12.21",
+            "version": "0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "2fb3b1c1d85e784a55e5806cf50734e5aa872eb4"
+                "reference": "bb3b32dd590cbd0deb67c2ce8ae32801357ff059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/2fb3b1c1d85e784a55e5806cf50734e5aa872eb4",
-                "reference": "2fb3b1c1d85e784a55e5806cf50734e5aa872eb4",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/bb3b32dd590cbd0deb67c2ce8ae32801357ff059",
+                "reference": "bb3b32dd590cbd0deb67c2ce8ae32801357ff059",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.5.6"
+                "phpstan/phpstan": "^1.6.8"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.2",
@@ -177,7 +177,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.12.21"
+                "source": "https://github.com/rectorphp/rector/tree/0.13.0"
             },
             "funding": [
                 {
@@ -185,7 +185,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-18T12:12:41+00:00"
+            "time": "2022-05-23T10:26:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
https://jira.corp.magento.com/browse/AC-3098 Fix function Helpers/Commenting/PHPDocFormattingValidator::hasDeprecatedWellFormatted

Updates:
- The @see tag must be present when there is a @deprecated tag.
- They both cannot be empty.
- If these conditions are not satisfied, a warning should be raised.