### PR TITLE
Class properties that have types should not require a DocBlock

### DIFF
--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -194,4 +194,6 @@ class correctlyFormattedClassMemberDocBlock
      * @see Message with some reference
      */
     protected string $itIsCorrect;
+
+    private string $typedPropertyWithoutComment;
 }


### PR DESCRIPTION
Fixes #404 

If a class property has a type, then there should not be a requirement for a DocBlock.
A DocBlock can still be added if desired - this change simply removes the warning for a missing comment block when the property has a defined type.

Note - this does not validate that the type is valid, only that it is not specifically _**invalid**_ in the same way as https://github.com/magento/magento-coding-standard/blob/develop/Magento2/Sniffs/Annotation/MethodArgumentsSniff.php

Additional:  This issue was originally raised against the documentation page (https://github.com/AdobeDocs/commerce-php/issues/23), and was suggested to be raised directly here. The documentation would need to be updated to reflect that DocBlocks are only required for properties without a type.