### PR TITLE
Prevent ESlint from using .eslintrc config file(s) outside of eslint/rules

### DIFF
--- a/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/config/configured_rule.php
+++ b/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/config/configured_rule.php
@@ -6,9 +6,8 @@
 declare(strict_types=1);
 
 use Magento2\Rector\Src\AddArrayAccessInterfaceReturnTypes;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(AddArrayAccessInterfaceReturnTypes::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddArrayAccessInterfaceReturnTypes::class);
 };

--- a/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/config/configured_rule.php
@@ -6,9 +6,8 @@
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplaceMbStrposNullLimit;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplaceMbStrposNullLimit::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceMbStrposNullLimit::class);
 };

--- a/Magento2/Rector/Tests/ReplaceNewDateTimeNull/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplaceNewDateTimeNull/config/configured_rule.php
@@ -6,9 +6,8 @@
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplaceNewDateTimeNull;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplaceNewDateTimeNull::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceNewDateTimeNull::class);
 };

--- a/Magento2/Rector/Tests/ReplacePregSplitNullLimit/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplacePregSplitNullLimit/config/configured_rule.php
@@ -6,9 +6,8 @@
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplacePregSplitNullLimit;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplacePregSplitNullLimit::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplacePregSplitNullLimit::class);
 };

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "phpcompatibility/php-compatibility": "^9.3",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "rector/rector": "^0.13.0"
+        "rector/rector": "^0.13.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "phpcompatibility/php-compatibility": "^9.3",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "rector/rector": "^0.13.7"
+        "rector/rector": "^0.13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed0a8b0a2d5dfb5268804fff7dd8ff83",
+    "content-hash": "4545f720f14d1d67c1b4684e624da98b",
     "packages": [
         {
             "name": "phpcompatibility/php-compatibility",
@@ -70,16 +70,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.7.13",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "86ffc063bfd8f264c9eba568e84b0225a6090d09"
+                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/86ffc063bfd8f264c9eba568e84b0225a6090d09",
-                "reference": "86ffc063bfd8f264c9eba568e84b0225a6090d09",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b7648d4ee9321665acaf112e49da9fd93df8fbd5",
+                "reference": "b7648d4ee9321665acaf112e49da9fd93df8fbd5",
                 "shasum": ""
             },
             "require": {
@@ -105,7 +105,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.7.13"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.0"
             },
             "funding": [
                 {
@@ -125,28 +125,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-13T15:15:39+00:00"
+            "time": "2022-06-29T08:53:31+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.13.5",
+            "version": "0.13.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "4170aad2943b150149ba9594c34539e06ced6c6b"
+                "reference": "3574bf6399ae3951e31f3a9481e22ddb2f2f08b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/4170aad2943b150149ba9594c34539e06ced6c6b",
-                "reference": "4170aad2943b150149ba9594c34539e06ced6c6b",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/3574bf6399ae3951e31f3a9481e22ddb2f2f08b2",
+                "reference": "3574bf6399ae3951e31f3a9481e22ddb2f2f08b2",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.7.10"
+                "phpstan/phpstan": "^1.8"
             },
             "conflict": {
-                "phpstan/phpdoc-parser": "<1.2",
+                "phpstan/phpdoc-parser": "<1.6.2",
                 "rector/rector-cakephp": "*",
                 "rector/rector-doctrine": "*",
                 "rector/rector-laravel": "*",
@@ -177,7 +177,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.13.5"
+                "source": "https://github.com/rectorphp/rector/tree/0.13.7"
             },
             "funding": [
                 {
@@ -185,20 +185,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-06-09T12:54:02+00:00"
+            "time": "2022-06-29T12:00:57+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -241,7 +241,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-13T06:31:38+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "webonyx/graphql-php",
@@ -1154,16 +1154,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.20",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
-                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -1197,7 +1197,6 @@
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -1241,7 +1240,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -1253,7 +1252,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-01T12:37:26+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4545f720f14d1d67c1b4684e624da98b",
+    "content-hash": "ed0a8b0a2d5dfb5268804fff7dd8ff83",
     "packages": [
         {
             "name": "phpcompatibility/php-compatibility",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "eslint/.eslintrc",
   "scripts": {
-    "eslint": "./node_modules/.bin/eslint -c eslint/.eslintrc --rulesdir eslint/rules"
+    "eslint": "./node_modules/.bin/eslint --no-eslintrc -c eslint/.eslintrc --rulesdir eslint/rules"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR adds `--no-eslintrc` flag to ESlint call to prevent linter from using `.eslintrc*` file(s) outside of `eslint/rules` directory.
Reference: https://eslint.org/docs/latest/user-guide/configuring/configuration-files#using-configuration-files