### PR TITLE
Fix Rector tests

### DIFF
--- a/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/config/configured_rule.php
+++ b/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/config/configured_rule.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Copyright 2021 Adobe
+ * Copyright 2022 Adobe
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
 
 use Magento2\Rector\Src\AddArrayAccessInterfaceReturnTypes;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(AddArrayAccessInterfaceReturnTypes::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddArrayAccessInterfaceReturnTypes::class);
 };

--- a/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/config/configured_rule.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Copyright 2021 Adobe
+ * Copyright 2022 Adobe
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplaceMbStrposNullLimit;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplaceMbStrposNullLimit::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceMbStrposNullLimit::class);
 };

--- a/Magento2/Rector/Tests/ReplaceNewDateTimeNull/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplaceNewDateTimeNull/config/configured_rule.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Copyright 2021 Adobe
+ * Copyright 2022 Adobe
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplaceNewDateTimeNull;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplaceNewDateTimeNull::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplaceNewDateTimeNull::class);
 };

--- a/Magento2/Rector/Tests/ReplacePregSplitNullLimit/config/configured_rule.php
+++ b/Magento2/Rector/Tests/ReplacePregSplitNullLimit/config/configured_rule.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * Copyright 2021 Adobe
+ * Copyright 2022 Adobe
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
 
 use Magento2\Rector\Src\ReplacePregSplitNullLimit;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Config\RectorConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->set(ReplacePregSplitNullLimit::class);
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ReplacePregSplitNullLimit::class);
 };


### PR DESCRIPTION
This PR fixes Rector tests by using RectorConfig instead of Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator 