### PR TITLE
Include all Magento2 sniffs in Magento2Framework

### DIFF
--- a/Magento2Framework/ruleset.xml
+++ b/Magento2Framework/ruleset.xml
@@ -4,6 +4,8 @@
 
     <arg name="extensions" value="php,phtml,graphqls/GRAPHQL,less/CSS,html/CSS,css/CSS,xml,js/JS"/>
 
+    <rule ref="Magento2" />
+
     <rule ref="Magento2Framework.Header.License">
         <severity>5</severity>
         <type>warning</type>


### PR DESCRIPTION
I have recently opened a pull request on https://github.com/magento/magento2. When I ran the static analysis automated test, some complaints were raised (for unchanged parts of the files which were being fixed/modified). To see these locally, I ran `phpcs --standard=Magento2Framework path-to/file.php`, however not all the complaints showed. When I ran `phpcs --standard=Magento2 path-to/file.php` the other complaints were visible. It doesn't seem right that the `Magento2Framework` standard doesn't include the rules defined in the `Magento2` standard. This pull request fixes this inconsistency.