### PR TITLE
Allow to skip see tag in annotation with specific deprecated comment

### DIFF
--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 class PHPDocFormattingValidator
 {
     private const REMOVED_IN_VERSION = 'removed in version';
+    private const WITHOUT_REPLACEMENT = 'without replacement';
 
     /**
      * Finds matching PHPDoc for current pointer
@@ -125,10 +126,11 @@ class PHPDocFormattingValidator
         }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            if (!stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0)) {
-                return false;
+            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) &&
+                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0)) {
+                return true;
             }
-            return true;
+            return false;
         }
 
         return $tokens[$seePtr + 2]['code'] === T_DOC_COMMENT_STRING;

--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -13,6 +13,8 @@ use PHP_CodeSniffer\Files\File;
  */
 class PHPDocFormattingValidator
 {
+    private const REMOVED_IN_VERSION = 'removed in version';
+
     /**
      * Finds matching PHPDoc for current pointer
      *
@@ -123,7 +125,10 @@ class PHPDocFormattingValidator
         }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            return false;
+            if (!stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0)) {
+                return false;
+            }
+            return true;
         }
 
         return $tokens[$seePtr + 2]['code'] === T_DOC_COMMENT_STRING;

--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -13,9 +13,6 @@ use PHP_CodeSniffer\Files\File;
  */
 class PHPDocFormattingValidator
 {
-    private const REMOVED_IN_VERSION = 'removed in version';
-    private const WITHOUT_REPLACEMENT = 'without replacement';
-
     /**
      * Finds matching PHPDoc for current pointer
      *
@@ -126,8 +123,10 @@ class PHPDocFormattingValidator
         }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) !== false &&
-                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0) !== false) {
+            if (preg_match(
+                "/This [a-zA-Z]* will be removed in version \d.\d.\d without replacement/",
+                $tokens[$deprecatedPtr + 2]['content']
+            )) {
                 return true;
             }
             return false;

--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -126,8 +126,8 @@ class PHPDocFormattingValidator
         }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) &&
-                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0)) {
+            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) >= 0 &&
+                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0) >= 0) {
                 return true;
             }
             return false;

--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -126,8 +126,8 @@ class PHPDocFormattingValidator
         }
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
-            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) >= 0 &&
-                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0) >= 0) {
+            if (stripos($tokens[$deprecatedPtr + 2]['content'], self::REMOVED_IN_VERSION, 0) !== false &&
+                stripos($tokens[$deprecatedPtr + 2]['content'], self::WITHOUT_REPLACEMENT, 0) !== false) {
                 return true;
             }
             return false;

--- a/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
@@ -373,7 +373,7 @@ class MethodAnnotationFixture
     /**
      * This deprecated function is correct even though it only contains the @deprecated tag.
      *
-     * @deprecated It will be removed in version 1.0.0 without replacement
+     * @deprecated This method will be removed in version 1.0.0 without replacement
      */
     public function correctBecauseOfKeywordPhrase()
     {
@@ -383,7 +383,7 @@ class MethodAnnotationFixture
     /**
      * This deprecated function is correct even though it only contains the @deprecated tag.
      *
-     * @deprecated WOW! It will be removed in version 1.0.0 without replacement
+     * @deprecated WOW! This method will be removed in version 1.0.0 without replacement
      */
     public function alsoCorrectBecauseOfKeywordPhrase()
     {

--- a/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
@@ -369,4 +369,24 @@ class MethodAnnotationFixture
     {
         return true;
     }
+
+    /**
+     * This deprecated function is correct even though it only contains the @deprecated tag.
+     *
+     * @deprecated It will be removed in version 1.0.0
+     */
+    public function correctBecauseOfKeywordPhrase()
+    {
+        return false;
+    }
+
+    /**
+     * This deprecated function is correct even though it only contains the @deprecated tag.
+     *
+     * @deprecated WOW! It will be removed in version 1.0.0
+     */
+    public function alsoCorrectBecauseOfKeywordPhrase()
+    {
+        return false;
+    }
 }

--- a/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
@@ -373,7 +373,7 @@ class MethodAnnotationFixture
     /**
      * This deprecated function is correct even though it only contains the @deprecated tag.
      *
-     * @deprecated It will be removed in version 1.0.0
+     * @deprecated It will be removed in version 1.0.0 without replacement
      */
     public function correctBecauseOfKeywordPhrase()
     {
@@ -383,7 +383,7 @@ class MethodAnnotationFixture
     /**
      * This deprecated function is correct even though it only contains the @deprecated tag.
      *
-     * @deprecated WOW! It will be removed in version 1.0.0
+     * @deprecated WOW! It will be removed in version 1.0.0 without replacement
      */
     public function alsoCorrectBecauseOfKeywordPhrase()
     {

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -162,3 +162,20 @@ class OldHandler
 {
 
 }
+
+/**
+ * @deprecated It will be removed in version 1.0.0
+ */
+class DeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated It's also deprecated, but it will be removed in version 1.0.0
+ */
+class AlsoDeprecatedButHandler
+{
+
+}
+

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -164,7 +164,7 @@ class OldHandler
 }
 
 /**
- * @deprecated It will be removed in version 1.0.0 without replacement
+ * @deprecated This class will be removed in version 1.0.0 without replacement
  */
 class DeprecatedButHandler
 {
@@ -172,7 +172,7 @@ class DeprecatedButHandler
 }
 
 /**
- * @deprecated It's also deprecated, but it will be removed in version 1.0.0 without replacement
+ * @deprecated It's also deprecated - This class will be removed in version 1.0.0 without replacement
  */
 class AlsoDeprecatedButHandler
 {

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -164,7 +164,7 @@ class OldHandler
 }
 
 /**
- * @deprecated It will be removed in version 1.0.0
+ * @deprecated It will be removed in version 1.0.0 without replacement
  */
 class DeprecatedButHandler
 {
@@ -172,7 +172,7 @@ class DeprecatedButHandler
 }
 
 /**
- * @deprecated It's also deprecated, but it will be removed in version 1.0.0
+ * @deprecated It's also deprecated, but it will be removed in version 1.0.0 without replacement
  */
 class AlsoDeprecatedButHandler
 {

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
@@ -155,7 +155,7 @@ interface DoNotCareHandler
 }
 
 /**
- * @deprecated This interface will be removed in version 1.0.0
+ * @deprecated This interface will be removed in version 1.0.0 without replacement
  */
 interface DeprecatedButHandler
 {
@@ -163,7 +163,7 @@ interface DeprecatedButHandler
 }
 
 /**
- * @deprecated Yeah! This interface will be removed in version 1.0.0
+ * @deprecated Yeah! This interface will be removed in version 1.0.0 without replacement
  */
 interface AlsoDeprecatedButHandler
 {

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
@@ -153,3 +153,19 @@ interface DoNotCareHandler
 {
 
 }
+
+/**
+ * @deprecated This interface will be removed in version 1.0.0
+ */
+interface DeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated Yeah! This interface will be removed in version 1.0.0
+ */
+interface AlsoDeprecatedButHandler
+{
+
+}

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -194,4 +194,10 @@ class correctlyFormattedClassMemberDocBlock
      * @see Message with some reference
      */
     protected string $itIsCorrect;
+
+    /**
+     * @var string
+     * @deprecated This property will be removed in version 1.0.0
+     */
+    protected string $deprecatedWithKeyword;
 }

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -197,7 +197,7 @@ class correctlyFormattedClassMemberDocBlock
 
     /**
      * @var string
-     * @deprecated This property will be removed in version 1.0.0
+     * @deprecated This property will be removed in version 1.0.0 without replacement
      */
     protected string $deprecatedWithKeyword;
 }

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
@@ -63,4 +63,14 @@ class Profiler
      * @see
      */
     const d = 100;
+
+    /**
+     * @deprecated This constant will be removed in version 1.0.0
+     */
+    const KEYWORD_PHRASE = false;
+
+    /**
+     * @deprecated It's awesome - This constant will be removed in version 1.0.0
+     */
+    const WITH_KEYWORD_PHRASE = false;
 }

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
@@ -65,12 +65,12 @@ class Profiler
     const d = 100;
 
     /**
-     * @deprecated This constant will be removed in version 1.0.0
+     * @deprecated This constant will be removed in version 1.0.0 without replacement
      */
     const KEYWORD_PHRASE = false;
 
     /**
-     * @deprecated It's awesome - This constant will be removed in version 1.0.0
+     * @deprecated It's awesome - This constant will be removed in version 1.0.0 without replacement
      */
     const WITH_KEYWORD_PHRASE = false;
 }


### PR DESCRIPTION
For deprecated code with no replacement as that functionality is not provided anymore, use *This method will be removed in version 2.x.x without replacement* as keyword phrase in @deprecated description in addition to deprecation motif. That keyword phrase will help us identify @deprecated annotations that do not need @see.

https://github.com/magento-commerce/development-guild/issues/191
https://jira.corp.adobe.com/browse/LYNX-32