### PR TITLE
AC-7098: Performance issue in TableNameSniff with big array

### DIFF
--- a/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/AddArrayAccessInterfaceReturnTypesTest.php
+++ b/Magento2/Rector/Tests/AddArrayAccessInterfaceReturnTypes/AddArrayAccessInterfaceReturnTypesTest.php
@@ -16,9 +16,9 @@ class AddArrayAccessInterfaceReturnTypesTest extends AbstractRectorTestCase
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $fileInfo): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($fileInfo);
     }
 
     /**

--- a/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/ReplaceMbStrposNullLimitTest.php
+++ b/Magento2/Rector/Tests/ReplaceMbStrposNullLimit/ReplaceMbStrposNullLimitTest.php
@@ -16,9 +16,9 @@ class ReplaceMbStrposNullLimitTest extends AbstractRectorTestCase
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $fileInfo): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($fileInfo);
     }
 
     /**

--- a/Magento2/Rector/Tests/ReplaceNewDateTimeNull/ReplaceNewDateTimeNullTest.php
+++ b/Magento2/Rector/Tests/ReplaceNewDateTimeNull/ReplaceNewDateTimeNullTest.php
@@ -16,9 +16,9 @@ class ReplaceNewDateTimeNullTest extends AbstractRectorTestCase
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $fileInfo): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($fileInfo);
     }
 
     /**

--- a/Magento2/Rector/Tests/ReplacePregSplitNullLimit/ReplacePregSplitNullLimitTest.php
+++ b/Magento2/Rector/Tests/ReplacePregSplitNullLimit/ReplacePregSplitNullLimitTest.php
@@ -16,9 +16,9 @@ class ReplacePregSplitNullLimitTest extends AbstractRectorTestCase
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $fileInfo): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($fileInfo);
     }
 
     /**

--- a/Magento2/Sniffs/Legacy/TableNameSniff.php
+++ b/Magento2/Sniffs/Legacy/TableNameSniff.php
@@ -189,8 +189,10 @@ class TableNameSniff implements Sniff
     private function checkOccurrencesInArray(File $phpcsFile, int $stackPtr, array $tokens): void
     {
         $aliasPos = $phpcsFile->findPrevious(
-            T_CONSTANT_ENCAPSED_STRING,
-            $stackPtr -1
+            T_WHITESPACE,
+            $stackPtr - 1,
+            null,
+            true,
         );
 
         $alias = trim($tokens[$aliasPos]['content'], '\'"');

--- a/Magento2/Tests/Legacy/TableNameUnitTest.inc
+++ b/Magento2/Tests/Legacy/TableNameUnitTest.inc
@@ -28,6 +28,8 @@ $select = $connection->select()->from(
     ['main_table' => 'magento_sample_table']
 );
 
+$fooBar=array(0=>array(125,0,875,750),'33' =>array(85,0,194,716), 10 => 100);
+
 class Collection extends \Magento\Sales\Model\ResourceModel\Report\Order\Collection
 {
     /**

--- a/Magento2/Tests/Legacy/TableNameUnitTest.php
+++ b/Magento2/Tests/Legacy/TableNameUnitTest.php
@@ -19,7 +19,7 @@ class TableNameUnitTest extends AbstractSniffUnitTest
             7 => 1,
             16 => 1,
             20 => 1,
-            38 => 1,
+            40 => 1,
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "phpcompatibility/php-compatibility": "^9.3",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "rector/rector": "^0.13.0"
+        "rector/rector": "^0.14.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a50d1c346c96a8ad6ecdc3d142d1fc3e",
+    "content-hash": "c101090e4e439fe14f68b90ca3dde531",
     "packages": [
         {
             "name": "phpcompatibility/php-compatibility",
@@ -70,16 +70,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.9",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2"
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2",
-                "reference": "3a72d9d9f2528fbd50c2d8fcf155fd9f74ade3f2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa",
                 "shasum": ""
             },
             "require": {
@@ -109,7 +109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.9"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.2"
             },
             "funding": [
                 {
@@ -125,35 +125,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-13T13:40:18+00:00"
+            "time": "2022-11-10T09:56:11+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.13.10",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "d1e069db8ad3b4aea2b968248370c21415e4c180"
+                "reference": "46ee9a173a2b2645ca92a75ffc17460139fa226e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d1e069db8ad3b4aea2b968248370c21415e4c180",
-                "reference": "d1e069db8ad3b4aea2b968248370c21415e4c180",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/46ee9a173a2b2645ca92a75ffc17460139fa226e",
+                "reference": "46ee9a173a2b2645ca92a75ffc17460139fa226e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.8.2"
+                "phpstan/phpstan": "^1.9.0"
             },
             "conflict": {
-                "phpstan/phpdoc-parser": "<1.6.2",
-                "rector/rector-cakephp": "*",
                 "rector/rector-doctrine": "*",
-                "rector/rector-laravel": "*",
-                "rector/rector-nette": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-php-parser": "*",
                 "rector/rector-phpoffice": "*",
                 "rector/rector-phpunit": "*",
-                "rector/rector-prefixed": "*",
                 "rector/rector-symfony": "*"
             },
             "bin": [
@@ -162,7 +159,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "0.13-dev"
+                    "dev-main": "0.14-dev"
                 }
             },
             "autoload": {
@@ -177,7 +174,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.13.10"
+                "source": "https://github.com/rectorphp/rector/tree/0.14.8"
             },
             "funding": [
                 {
@@ -185,7 +182,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-03T12:48:10+00:00"
+            "time": "2022-11-14T14:09:49+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -442,16 +439,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.1",
+            "version": "v4.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
                 "shasum": ""
             },
             "require": {
@@ -492,9 +489,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
             },
-            "time": "2022-09-04T07:30:47+00:00"
+            "time": "2022-11-12T15:38:23+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -609,16 +606,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
                 "shasum": ""
             },
             "require": {
@@ -674,7 +671,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
             },
             "funding": [
                 {
@@ -682,7 +679,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2022-11-18T07:47:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -927,16 +924,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.5.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
                 "shasum": ""
             },
             "require": {
@@ -1009,7 +1006,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
             },
             "funding": [
                 {
@@ -1025,7 +1022,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2022-10-28T06:00:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
### Fix summary

The performance of TableNameSniff degradated with a big array and structure like this
`$fooBar=array(0=>array(125,0,875,750),1 =>array(85,0,194,716), 2 => 100);` 
But TableNameSniff expected to process the associative array similar to
`['main_table_name' => 'magento/sample_table']` 
in result, [$phpcsFile->findPrevious](https://github.com/magento/magento-coding-standard/blob/1452ed3dd49f11b2b7743048595e19e02e45f402/Magento2/Sniffs/Legacy/TableNameSniff.php#L191-L194) could not find associate array key in [$stackPtr -1](https://github.com/magento/magento-coding-standard/blob/1452ed3dd49f11b2b7743048595e19e02e45f402/Magento2/Sniffs/Legacy/TableNameSniff.php#L193)

**The fix is to make findPrevious to find any non whitespace token as array key** 

### Related Pull Requests
 https://github.com/magento-commerce/mray/pull/158
<!-- related pull request placeholder -->