### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,6 @@ To use within your Magento 2 project you can use:
 composer require --dev magento/magento-coding-standard
 ```
 
-Due to security, when installed this way the Magento standard for phpcs cannot be added automatically.
-You can achieve this by adding the following to your project's `composer.json`:
-
-```json
-"scripts": {
-    "post-install-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
-    ],
-    "post-update-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
-    ]
-}
-```
-
 ### Installation for development
 
 You can install Magento Coding Standard by cloning this GitHub repo:
@@ -122,7 +108,7 @@ The rules from rector that are applied are set inside the config file: `rector.p
 The option `--dry-run` displays errors found, but code is not automatically fixed.
 
 To run rector for `magento` projects you need to:
-- Specify the magento path and the autoload file for the magento project: 
+- Specify the magento path and the autoload file for the magento project:
 ```bash
 vendor/bin/rector process MAGENTO_PATH --dry-run --autoload-file MAGENTO_AUTOLOAD_FILE
 ```

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "version": "40",
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0 || ^1.0",
         "webonyx/graphql-php": "^15.0",
         "ext-simplexml": "*",
         "ext-dom": "*",
@@ -35,13 +36,9 @@
             "Magento2Framework\\": "Magento2Framework/"
         }
     },
-    "scripts": {
-        "post-install-cmd": "vendor/bin/phpcs --config-set installed_paths ../../..,../../magento/php-compatibility-fork/PHPCompatibility",
-        "post-update-cmd": "vendor/bin/phpcs --config-set installed_paths ../../..,../../magento/php-compatibility-fork/PHPCompatibility"
-    },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": false
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8985c3cd041f22779a719754bfc74d0d",
+    "content-hash": "58519a88bd794b003810c3873b78aeb4",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
The installation instructions for this coding standard are unnecessarily complex. Composer plugins are capable of performing the necessary registration automatically, without requiring the user to manually set up (or alter) any `scripts` sections in `composer.json`. The main Magento repository uses `dealerdirect/phpcodesniffer-composer-installer` to register the coding standard; let's use the same here.

See https://github.com/magento/magento2/blob/11846a1a10539470f2fe1522030ff42d62daa562/composer.json#L110 / https://github.com/magento/magento2/pull/36791

Fixes #390