### PR TITLE
Allow more version numbers in `@deprecated` tag

### DIFF
--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -4,6 +4,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento2\Helpers\Commenting;
 
 use PHP_CodeSniffer\Files\File;
@@ -18,6 +19,7 @@ class PHPDocFormattingValidator
      *
      * @param int $startPtr
      * @param File $phpcsFile
+     *
      * @return int
      */
     public function findPHPDoc($startPtr, $phpcsFile)
@@ -53,6 +55,7 @@ class PHPDocFormattingValidator
      * @param int $namePtr
      * @param int $commentStartPtr
      * @param array $tokens
+     *
      * @return bool
      */
     public function providesMeaning($namePtr, $commentStartPtr, $tokens)
@@ -113,6 +116,7 @@ class PHPDocFormattingValidator
      *
      * @param int $commentStartPtr
      * @param array $tokens
+     *
      * @return bool
      */
     public function hasDeprecatedWellFormatted($commentStartPtr, $tokens)
@@ -129,6 +133,7 @@ class PHPDocFormattingValidator
             )) {
                 return true;
             }
+
             return false;
         }
 
@@ -141,6 +146,7 @@ class PHPDocFormattingValidator
      * @param string $tag
      * @param int $commentStartPtr
      * @param array $tokens
+     *
      * @return int
      */
     private function getTagPosition($tag, $commentStartPtr, $tokens)

--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -124,7 +124,7 @@ class PHPDocFormattingValidator
         $seePtr = $this->getTagPosition('@see', $commentStartPtr, $tokens);
         if ($seePtr === -1) {
             if (preg_match(
-                "/This [a-zA-Z]* will be removed in version \d.\d.\d without replacement/",
+                "/This [a-zA-Z]+ will be removed in version \d+\.\d+\.\d+ without replacement/",
                 $tokens[$deprecatedPtr + 2]['content']
             )) {
                 return true;

--- a/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
+++ b/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.inc
@@ -383,9 +383,29 @@ class MethodAnnotationFixture
     /**
      * This deprecated function is correct even though it only contains the @deprecated tag.
      *
+     * @deprecated This method will be removed in version 123.45.6789 without replacement
+     */
+    public function correctBecauseOfKeywordPhraseLongVersion()
+    {
+        return false;
+    }
+
+    /**
+     * This deprecated function is correct even though it only contains the @deprecated tag.
+     *
      * @deprecated WOW! This method will be removed in version 1.0.0 without replacement
      */
     public function alsoCorrectBecauseOfKeywordPhrase()
+    {
+        return false;
+    }
+
+    /**
+     * This deprecated function is correct even though it only contains the @deprecated tag.
+     *
+     * @deprecated WOW! This method will be removed in version 123.45.6789 without replacement
+     */
+    public function alsoCorrectBecauseOfKeywordPhraseLongVersion()
     {
         return false;
     }

--- a/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.php
+++ b/Magento2/Tests/Annotation/MethodAnnotationStructureUnitTest.php
@@ -40,10 +40,10 @@ class MethodAnnotationStructureUnitTest extends AbstractSniffUnitTest
             288 => 1,
             289 => 1,
             298 => 1,
-            396 => 1,
-            407 => 1,
-            418 => 1,
-            424 => 1,
+            416 => 1,
+            427 => 1,
+            438 => 1,
+            444 => 1,
         ];
     }
 

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc
@@ -172,9 +172,25 @@ class DeprecatedButHandler
 }
 
 /**
+ * @deprecated This class will be removed in version 123.45.6789 without replacement
+ */
+class DeprecatedButHandlerLongVersion
+{
+
+}
+
+/**
  * @deprecated It's also deprecated - This class will be removed in version 1.0.0 without replacement
  */
 class AlsoDeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated It's also deprecated - This class will be removed in version 123.45.6789 without replacement
+ */
+class AlsoDeprecatedButHandlerLongVersion
 {
 
 }

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc.fixed
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.1.inc.fixed
@@ -152,9 +152,25 @@ class DeprecatedButHandler
 }
 
 /**
+ * @deprecated This class will be removed in version 123.45.6789 without replacement
+ */
+class DeprecatedButHandlerLongVersion
+{
+
+}
+
+/**
  * @deprecated It's also deprecated - This class will be removed in version 1.0.0 without replacement
  */
 class AlsoDeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated It's also deprecated - This class will be removed in version 123.45.6789 without replacement
+ */
+class AlsoDeprecatedButHandlerLongVersion
 {
 
 }

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc
@@ -172,9 +172,25 @@ interface DeprecatedButHandler
 }
 
 /**
+ * @deprecated This interface will be removed in version 123.45.6789 without replacement
+ */
+interface DeprecatedButHandlerLongVersion
+{
+
+}
+
+/**
  * @deprecated Yeah! This interface will be removed in version 1.0.0 without replacement
  */
 interface AlsoDeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated Yeah! This interface will be removed in version 123.45.6789 without replacement
+ */
+interface AlsoDeprecatedButHandlerLongVersion
 {
 
 }

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc.fixed
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.2.inc.fixed
@@ -152,9 +152,25 @@ interface DeprecatedButHandler
 }
 
 /**
+ * @deprecated This interface will be removed in version 123.45.6789 without replacement
+ */
+interface DeprecatedButHandlerLongVersion
+{
+
+}
+
+/**
  * @deprecated Yeah! This interface will be removed in version 1.0.0 without replacement
  */
 interface AlsoDeprecatedButHandler
+{
+
+}
+
+/**
+ * @deprecated Yeah! This interface will be removed in version 123.45.6789 without replacement
+ */
+interface AlsoDeprecatedButHandlerLongVersion
 {
 
 }

--- a/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
+++ b/Magento2/Tests/Commenting/ClassAndInterfacePHPDocFormattingUnitTest.php
@@ -4,6 +4,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento2\Tests\Commenting;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
@@ -37,7 +38,7 @@ class ClassAndInterfacePHPDocFormattingUnitTest extends AbstractSniffUnitTest
             109 => 1,
             118 => 1,
             127 => 1,
-            183 => 1,
+            199 => 1,
         ];
     }
 }

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -203,6 +203,12 @@ class correctlyFormattedClassMemberDocBlock
 
     /**
      * @var string
+     * @deprecated This property will be removed in version 123.45.6789 without replacement
+     */
+    protected string $deprecatedWithKeywordLongVersion;
+
+    /**
+     * @var string
      */
     protected readonly string $readOnlyString;
 

--- a/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
+++ b/Magento2/Tests/Commenting/ConstantsPHPDocFormattingUnitTest.2.inc
@@ -70,7 +70,17 @@ class Profiler
     const KEYWORD_PHRASE = false;
 
     /**
+    * @deprecated This constant will be removed in version 123.45.6789 without replacement
+    */
+    const KEYWORD_PHRASE_LONG_VERSION = false;
+
+    /**
      * @deprecated It's awesome - This constant will be removed in version 1.0.0 without replacement
      */
     const WITH_KEYWORD_PHRASE = false;
+
+    /**
+     * @deprecated It's awesome - This constant will be removed in version 123.45.6789 without replacement
+     */
+    const WITH_KEYWORD_PHRASE_LONG_VERSION = false;
 }


### PR DESCRIPTION
While reviewing the Static Test failures in https://github.com/magento/magento2/pull/36976 (which are out of scope for the intended change), I noticed that the message required for a `@deprecated` tag does not support the version numbers that Adobe use for Magento modules. For example, the `magento/module-backend` module is currently version `102.0.6`, but the regular expression in the coding standard does not allow version numbers with more than one digit per part. This pull request fixes this oversight.