### PR TITLE
Make Unescaped Output Fail With Error Severity 10

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -94,6 +94,10 @@
         <severity>10</severity>
         <type>error</type>
     </rule>
+    <rule ref="Magento2.Security.XssTemplate.FoundUnescaped">
+        <severity>10</severity>
+        <type>error</type>
+    </rule>
     <rule ref="PSR1.Classes.ClassDeclaration">
         <severity>10</severity>
         <type>error</type>


### PR DESCRIPTION
# Description
Unescaped output should be grounds for failure - let's mark it as such.
