### PR TITLE
Add suggested replacement for \posix_isatty()

### DIFF
--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
@@ -104,6 +104,7 @@ class DiscouragedFunctionSniff extends ForbiddenFunctionsSniff
         '^parsekit_compile_string$' => null,
         '^pathinfo$' => 'Magento\Framework\Filesystem\Io\File::getPathInfo',
         '^pcntl_.*$' => null,
+        '^posix_isatty$' => 'stream_isatty',
         '^posix_.*$' => null,
         '^pfpro_.*$' => null,
         '^pfsockopen$' => null,


### PR DESCRIPTION
Per https://github.com/magento/magento2/pull/32690#discussion_r1194733290, it is recommended to use `stream_isatty()` instead of `posix_isatty()`.