### PR TITLE
Omit unnecessary files from distribution archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore
+/Magento2/Rector/Tests/ export-ignore
+/Magento2/Tests/ export-ignore
+/Magento2Framework/Tests/ export-ignore
+/package-lock.json export-ignore
+/package.json export-ignore
+/PHP_CodeSniffer/Tests/ export-ignore
+/phpunit-bootstrap.php export-ignore
+/phpunit.xml.dist export-ignore
+/rector.php export-ignore


### PR DESCRIPTION
These files are only useful when working directly on this standard, and not when consuming the standard. When installing this standard via Composer, these files can safely be excluded.

Closes https://github.com/magento/magento-coding-standard/issues/460