### PR TITLE
Allow graphql pretty formatted files

### DIFF
--- a/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
@@ -32,7 +32,7 @@ class ValidTypeNameSniff extends AbstractGraphQLSniff
         //compose entity name by making use of the next strings that we find until we hit a non-string token
         $name = '';
         for ($i=$stackPtr+1; $tokens[$i]['code'] === T_STRING; ++$i) {
-            $name .= $tokens[$i]['content'];
+            $name .= rtrim($tokens[$i]['content']);
         }
 
         $valid = Common::isCamelCaps($name, true, true, false);

--- a/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
@@ -32,6 +32,9 @@ class ValidTypeNameSniff extends AbstractGraphQLSniff
         //compose entity name by making use of the next strings that we find until we hit a non-string token
         $name = '';
         for ($i=$stackPtr+1; $tokens[$i]['code'] === T_STRING; ++$i) {
+            /**
+             * @see \PHP_CodeSniffer\Tokenizers\GRAPHQL::tokenize Removing EOL character artificially added to token
+             */
             $name .= rtrim($tokens[$i]['content']);
         }
 

--- a/Magento2/Tests/GraphQL/ValidTypeNameUnitTest.graphqls
+++ b/Magento2/Tests/GraphQL/ValidTypeNameUnitTest.graphqls
@@ -1,5 +1,7 @@
 # Valid type names.
 type ValidCamelCaseType {}
+type ValidCamelCaseTypeNewLineBrace
+{}
 interface ValidCamelCaseInterface {}
 enum ValidCamelCaseEnum {}
 

--- a/Magento2/Tests/GraphQL/ValidTypeNameUnitTest.php
+++ b/Magento2/Tests/GraphQL/ValidTypeNameUnitTest.php
@@ -23,21 +23,21 @@ class ValidTypeNameUnitTest extends AbstractGraphQLSniffUnitTestCase
     protected function getErrorList()
     {
         return [
-            7 => 1,
-            8 => 1,
             9 => 1,
             10 => 1,
             11 => 1,
             12 => 1,
-            15 => 1,
-            16 => 1,
+            13 => 1,
+            14 => 1,
             17 => 1,
-            21 => 1,
+            18 => 1,
+            19 => 1,
             23 => 1,
             25 => 1,
-            35 => 1,
-            39 => 1,
-            43 => 1,
+            27 => 1,
+            37 => 1,
+            41 => 1,
+            45 => 1,
         ];
     }
 


### PR DESCRIPTION
Currently checks for GraphQL ValidTypeName assumes that type definitions are always one-liners. 
For a better readability it is much better to format GraphQL files so that they are multiline. 

```
type CartCampaign
    @doc(
        description: "CartCampaign returns the discount amount set in the quote"
    ) {
    full_discount_amount: Float
}
```

instead of

```
type CartCampaign @doc(description: "CartCampaign returns the discount amount set in the quote") {
    full_discount_amount: Float
}
```

There can many other tags like `@doc` and in current implementation all of them have to be in one line together with type to satisfy sniff. Changes in this PR will make pretty version to pass checks.  


`\PHP_CodeSniffer\Tokenizers\GRAPHQL::tokenize` adds `\n` to token content anyway (see `vendor/magento/magento-coding-standard/PHP_CodeSniffer/Tokenizers/GRAPHQL.php:134`) to not screw up with line numbers. 


This PR Closes #465 
