### PR TITLE
Allow installing latest coding standard on Magento 2.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "version": "32",
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "webonyx/graphql-php": "^15.0",
+        "webonyx/graphql-php": "^14.9|^15.0",
         "ext-simplexml": "*",
         "ext-dom": "*",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a1a72f8272e9cd2cb0dd520a56aeea2",
+    "content-hash": "eb59b21d1d43bc5c92e2460ca6519298",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
This pull request allows installing the latest version of coding standards to Magento 2.4.5-p5.
Currently it fails due to incompatibility with version of the `webonyx/graphql-php` package:
```bash
$ composer why-not magento/magento-coding-standard 32
magento/magento-coding-standard   32       requires         webonyx/graphql-php (^15.0)
magento/project-community-edition 2.4.5-p5 does not require webonyx/graphql-php (but v14.11.10 is installed)
magento/magento-coding-standard   32       requires         rector/rector (0.17.12)
magento/project-community-edition 2.4.5-p5 does not require rector/rector (but 0.14.8 is installed)
Not finding what you were looking for? Try calling `composer update "magento/magento-coding-standard:32" --dry-run` to get another view on the problem.
```

```bash
$ composer update "magento/magento-coding-standard:32" --dry-run -W
Loading composer repositories with package information
In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires magento/magento-coding-standard * -> satisfiable by magento/magento-coding-standard[32].
    - magento/magento-coding-standard 32 requires webonyx/graphql-php ^15.0 -> found webonyx/graphql-php[v15.0.0, ..., v15.8.0] but these were not loaded, likely because it conflicts with another require.
```

Magento 2.4.5-p5 requires version webonyx/graphql-php:~14.11.5, while coding standard currently requires ^15.0

```bash
$ composer why webonyx/graphql-php
magento/framework                 103.0.5-p5 requires webonyx/graphql-php (~14.11.6)
magento/magento-coding-standard   29         requires webonyx/graphql-php (^14.9)
magento/module-graph-ql           100.4.5    requires webonyx/graphql-php (~14.11.5)
magento/product-community-edition 2.4.5-p5   requires webonyx/graphql-php (~14.11.6)
```

This version upgrade was added in https://github.com/magento/magento-coding-standard/commit/2466e633462a7eeec3a16c08b321c43e09ca7b23#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R12. 

Since it doesn't contain any other updates than a composer, I would suggest allowing both versions, and make compatible with older and newer Magento versions.