### PR TITLE
Fix Class Property DocBlock sniff for union/intersection types

### DIFF
--- a/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassPropertyPHPDocFormattingSniff.php
@@ -30,8 +30,10 @@ class ClassPropertyPHPDocFormattingSniff extends AbstractVariableSniff
         T_STRING,
         T_COMMENT,
         T_NULLABLE,
-        T_BITWISE_AND,
+        T_TYPE_INTERSECTION,
         T_TYPE_UNION,
+        T_TYPE_OPEN_PARENTHESIS,
+        T_TYPE_CLOSE_PARENTHESIS,
         T_READONLY,
     ];
 

--- a/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
+++ b/Magento2/Tests/Commenting/ClassPropertyPHPDocFormattingUnitTest.inc
@@ -210,4 +210,19 @@ class correctlyFormattedClassMemberDocBlock
      * @var int
      */
     protected readonly int $readOnlyInteger;
+
+    /**
+     * @var Foo|Bar
+     */
+    protected Foo|Bar $unionType;
+
+    /**
+     * @var Bar&Foo
+     */
+    protected Foo&Bar $pureIntersectionType;
+
+    /**
+     * @var array|(Bar&Foo)
+     */
+    protected (Foo&Bar)|array $unionIntersectionType;
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "webonyx/graphql-php": "^15.0",
         "ext-simplexml": "*",
         "ext-dom": "*",
-        "squizlabs/php_codesniffer": "^3.6.1",
+        "squizlabs/php_codesniffer": "^3.10.0",
         "rector/rector": "^0.17.12",
         "phpcsstandards/phpcsutils": "^1.0.5",
         "magento/php-compatibility-fork": "^0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2538347534e520207948a130ccd78862",
+    "content-hash": "1175d1cf126194c812a9b844b35642e0",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -361,16 +361,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/86e5f5dd9a840c46810ebe5ff1885581c42a3017",
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017",
                 "shasum": ""
             },
             "require": {
@@ -380,11 +380,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -437,7 +437,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-07-21T23:26:44+00:00"
         },
         {
             "name": "webonyx/graphql-php",
@@ -2319,5 +2319,5 @@
         "ext-dom": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Since [PHP_CodeSniffer 3.7.0, there's a separate token `T_TYPE_INTERSECTION` for the `&` type-intersection specifier](https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/c80367101d241b7e4236a718ec96b13b227ad45c#diff-e454877e2ec518b7f88114961cfe972b091affd00d65b31ff01ee7d5dda7cdf8R1472), instead of using the same `T_BITWISE_AND` token for both type intersections and the bitwise operator. Due to this, the `Magento2.Commenting.ClassPropertyPHPDocFormatting` sniff fails to detect the DocBlock for intersection-typed properties in projects that use newer versions.

![image](https://github.com/user-attachments/assets/bc0f0754-1859-478e-b4da-7016e92a7262)

Also, since [PHP 8.2 added support for DNF types](https://wiki.php.net/rfc/dnf_types), two new tokens were added to [PHP_CodeSniffer in 3.10.0](https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/5ce28e96f4fa1aa2f752e65bf3cf3a9311d85af3#diff-4bb7ccfe32fb6c16f55609d4ccfce47f4750c0212312147fcc553eb89ce00e41R467-R468) for the parentheses.

This PR proposes pinning the minimum PHP_CodeSniffer version to `^3.10.0` in order to fully support the newer DNF types, while also fixing the sniff's allowed tokens to correctly detect DocBlocks for intersection-typed properties.