### PR TITLE
Resolve issues with regex include and exclude patterns in Magento 2 ruleset.xml

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -212,7 +212,7 @@
         <exclude-pattern>*\.xml$</exclude-pattern>
     </rule>
     <rule ref="Magento2.Html.HtmlBinding">
-        <include-pattern>*\/.phtml$</include-pattern>
+        <include-pattern>*\.phtml$</include-pattern>
         <severity>9</severity>
         <type>warning</type>
         <exclude-pattern>*\.xml$</exclude-pattern>

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -165,10 +165,10 @@
         <exclude-pattern>*\.js$</exclude-pattern>
     </rule>
     <rule ref="Magento2.Legacy.ClassReferencesInConfigurationFiles">
-        <include-pattern>*\/etc/*.xml$</include-pattern>
-        <exclude-pattern>*\/etc/wsdl.xml$</exclude-pattern>
-        <exclude-pattern>*\/etc/wsdl2.xml$</exclude-pattern>
-        <exclude-pattern>*\/etc/wsi.xml$</exclude-pattern>
+        <include-pattern>*/etc/*.xml$</include-pattern>
+        <exclude-pattern>*/etc/wsdl.xml$</exclude-pattern>
+        <exclude-pattern>*/etc/wsdl2.xml$</exclude-pattern>
+        <exclude-pattern>*/etc/wsi.xml$</exclude-pattern>
         <severity>10</severity>
         <type>error</type>
     </rule>

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -156,7 +156,7 @@
     <rule ref="Magento2.Legacy.Layout">
         <severity>10</severity>
         <type>error</type>
-        <include-pattern>*/view/(adminhtml|frontend|base)/*\/.xml</include-pattern>
+        <include-pattern>*/view/(adminhtml|frontend|base)/*/*.xml</include-pattern>
     </rule>
     <rule ref="Magento2.Legacy.RestrictedCode">
         <severity>10</severity>

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -307,12 +307,12 @@
         <type>warning</type>
     </rule>
     <rule ref="Magento2.Legacy.ModuleXML">
-        <include-pattern>*\/module.xml$</include-pattern>
+        <include-pattern>*/module.xml$</include-pattern>
         <severity>8</severity>
         <type>warning</type>
     </rule>
     <rule ref="Magento2.Legacy.DiConfig">
-        <include-pattern>*\/di.xml$</include-pattern>
+        <include-pattern>*/di.xml$</include-pattern>
         <severity>8</severity>
         <type>warning</type>
     </rule>
@@ -322,7 +322,7 @@
         <exclude-pattern>*\.xml$</exclude-pattern>
     </rule>
     <rule ref="Magento2.Legacy.WidgetXML">
-        <include-pattern>*\/widget.xml$</include-pattern>
+        <include-pattern>*/widget.xml$</include-pattern>
         <severity>8</severity>
         <type>warning</type>
     </rule>


### PR DESCRIPTION
See https://github.com/magento/magento-coding-standard/issues/485 for a detailed description of the issue.

These fixes makes the following assumptions and these will need to be verified by someone who knows why the rules were introduced in the first place and has more knowledge about phpcs and Magento than I do.

**Magento2.Legacy.Layout**
The existing rule seems to target files such as

- anything/view/adminhtml/anything/.xml
- anything/view/frontend/anything/.xml

I don't think thats right. I believe it should actually be targetting

- anything/view/adminhtml/anything/anything.xml
- anything/view/frontend/anything/anything.xml

The updated rule targets any xml file in any subfolder of a view/adminhtml, view/frontend or view/base folder. I think this was the intended target.

**Magento2.Html.HtmlBinding**
I believe the intention with this rule is to target any phtml file anywhere in the tree. The existing rule, as written, will target only files with the following paths

- .phtml
- somewhere/.phtml
- somewhere/somewhere/.phtml

In addition to this, escaping the first forward slash, as in the previous example, breaks things even more under windows. The replacement rule removes the escaping of forward slash so it works under both Linux and Windows, and corrects the rule to target paths such as

- something.phtml
- somewhere/something.phtml
- somewhere/somewhere/something.phtml

**Magento2.Legacy.ClassReferencesInConfigurationFiles**
I believe the intention with this rule is to target any xml file present in any etc folder, anywhere, but exclude wsdl.xml, wsdl2.xml and wsi.xml. There is no need to escape the leading forward slash, and by doing so, it stops the rule working under windows. The replacement rule removes the escaping of the first slash so it works under both Linux and Windows.

**Magento2.Legacy.ModuleXML**
**Magento2.Legacy.DiConfig**
**Magento2.Legacy.WidgetXML**
I believe the intention with these rules is to target any file named module.xml, widget.xml or di.xml, in any subfolder of the tree, but not the root. The existing rules escape the first forward slash, which results in the rule failing when running under windows. The rule is updated to remove the escaping so it works under both Linux and Windows. 

**QUESTION**: Why were all these forward slashes escaped in the rules. Is there something/some system I am overlooking that requires it?

For more detailed analysis see issue #485 

Tested under Ubuntu 24.04 and Windows 11/Cygwin