### PR TITLE
Update supported PHP versions to match Magento

### DIFF
--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -767,7 +767,7 @@
     </rule>
 
     <!-- PHPCompatibility configuration. -->
-    <config name="testVersion" value="8.1-8.2"/>
+    <config name="testVersion" value="8.1-8.3"/>
     <rule ref="PHPCompatibility">
         <exclude name="PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound" />
         <!-- Following sniffs have an equivalent in PHPCS -->


### PR DESCRIPTION
Version 2.4.7-p2 (which is the latest at time of writing) supports PHP versions 8.1.x and 8.2.x and 8.3.x. This change updates the PHPCompatibility configuration to scan for these versions.

https://github.com/magento/magento2/blob/2.4.7-p2/composer.json#L21
https://github.com/magento/magento2/blob/2.4.7-p1/composer.json#L21
https://github.com/magento/magento2/blob/2.4.7/composer.json#L21

This is related to https://github.com/magento/magento-coding-standard/issues/484 and https://github.com/magento/magento-coding-standard/issues/491