### PR TITLE
Require a strict_types declaration

### DIFF
--- a/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
+++ b/Magento2/Helpers/Commenting/PHPDocFormattingValidator.php
@@ -4,6 +4,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Helpers\Commenting;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Helpers/Tokenizer/AbstractTokenizer.php
+++ b/Magento2/Helpers/Tokenizer/AbstractTokenizer.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Helpers\Tokenizer;
 
 /**

--- a/Magento2/Helpers/Tokenizer/Parameter.php
+++ b/Magento2/Helpers/Tokenizer/Parameter.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Helpers\Tokenizer;
 
 /**

--- a/Magento2/Helpers/Tokenizer/Variable.php
+++ b/Magento2/Helpers/Tokenizer/Variable.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Helpers\Tokenizer;
 

--- a/Magento2/Sniffs/Classes/AbstractApiSniff.php
+++ b/Magento2/Sniffs/Classes/AbstractApiSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Classes;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Classes/DiscouragedDependenciesSniff.php
+++ b/Magento2/Sniffs/Classes/DiscouragedDependenciesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Classes;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/CodeAnalysis/EmptyBlockSniff.php
+++ b/Magento2/Sniffs/CodeAnalysis/EmptyBlockSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\CodeAnalysis;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ClassAndInterfacePHPDocFormattingSniff.php
@@ -4,6 +4,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Commenting;
 
 use Magento2\Helpers\Commenting\PHPDocFormattingValidator;

--- a/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
+++ b/Magento2/Sniffs/Commenting/ConstantsPHPDocFormattingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Commenting;
 
 use Magento2\Helpers\Commenting\PHPDocFormattingValidator;

--- a/Magento2/Sniffs/Exceptions/DirectThrowSniff.php
+++ b/Magento2/Sniffs/Exceptions/DirectThrowSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Exceptions;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Exceptions/ThrowCatchSniff.php
+++ b/Magento2/Sniffs/Exceptions/ThrowCatchSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Exceptions;
 

--- a/Magento2/Sniffs/Exceptions/TryProcessSystemResourcesSniff.php
+++ b/Magento2/Sniffs/Exceptions/TryProcessSystemResourcesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Exceptions;
 
 use function array_slice;

--- a/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
+++ b/Magento2/Sniffs/Functions/DiscouragedFunctionSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Functions;
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;

--- a/Magento2/Sniffs/Functions/StaticFunctionSniff.php
+++ b/Magento2/Sniffs/Functions/StaticFunctionSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Functions;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/GraphQL/AbstractGraphQLSniff.php
+++ b/Magento2/Sniffs/GraphQL/AbstractGraphQLSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\GraphQL;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/GraphQL/ValidArgumentNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidArgumentNameSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\GraphQL;
 

--- a/Magento2/Sniffs/GraphQL/ValidEnumValueSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidEnumValueSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\GraphQL;
 

--- a/Magento2/Sniffs/GraphQL/ValidFieldNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidFieldNameSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\GraphQL;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/GraphQL/ValidTopLevelFieldNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidTopLevelFieldNameSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\GraphQL;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
+++ b/Magento2/Sniffs/GraphQL/ValidTypeNameSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\GraphQL;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/Html/HtmlBindingSniff.php
+++ b/Magento2/Sniffs/Html/HtmlBindingSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Html;
 

--- a/Magento2/Sniffs/Html/HtmlCollapsibleAttributeSniff.php
+++ b/Magento2/Sniffs/Html/HtmlCollapsibleAttributeSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Html;
 

--- a/Magento2/Sniffs/Legacy/DiConfigSniff.php
+++ b/Magento2/Sniffs/Legacy/DiConfigSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 

--- a/Magento2/Sniffs/Legacy/EmailTemplateSniff.php
+++ b/Magento2/Sniffs/Legacy/EmailTemplateSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 

--- a/Magento2/Sniffs/Legacy/MageEntitySniff.php
+++ b/Magento2/Sniffs/Legacy/MageEntitySniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Legacy;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Legacy/ModuleXMLSniff.php
+++ b/Magento2/Sniffs/Legacy/ModuleXMLSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 

--- a/Magento2/Sniffs/Legacy/ObsoleteAclSniff.php
+++ b/Magento2/Sniffs/Legacy/ObsoleteAclSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Legacy;
 
 use DOMDocument;

--- a/Magento2/Sniffs/Legacy/ObsoleteConfigNodesSniff.php
+++ b/Magento2/Sniffs/Legacy/ObsoleteConfigNodesSniff.php
@@ -4,6 +4,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 

--- a/Magento2/Sniffs/Legacy/ObsoleteMenuSniff.php
+++ b/Magento2/Sniffs/Legacy/ObsoleteMenuSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Legacy;
 
 use DOMDocument;
@@ -15,7 +17,7 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class ObsoleteMenuSniff implements Sniff
 {
     private const WARNING_OBSOLETE_MENU_STRUCTURE = 'ObsoleteMenuStructure';
-    
+
     /**
      * @var string
      */

--- a/Magento2/Sniffs/Legacy/ObsoleteSystemConfigurationSniff.php
+++ b/Magento2/Sniffs/Legacy/ObsoleteSystemConfigurationSniff.php
@@ -4,6 +4,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 
@@ -41,13 +42,13 @@ class ObsoleteSystemConfigurationSniff implements Sniff
             $this->invalidXML($phpcsFile, $stackPtr);
             return;
         }
-        
+
         $foundElements = $xml->xpath('/config/tabs|/config/sections');
-        
+
         if ($foundElements === false) {
             return;
         }
-        
+
         foreach ($foundElements as $element) {
             $phpcsFile->addWarning(
                 "Obsolete system configuration structure detected in file.",

--- a/Magento2/Sniffs/Legacy/WidgetXMLSniff.php
+++ b/Magento2/Sniffs/Legacy/WidgetXMLSniff.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento2\Sniffs\Legacy;
 

--- a/Magento2/Sniffs/Legacy/WidgetXMLSniff.php
+++ b/Magento2/Sniffs/Legacy/WidgetXMLSniff.php
@@ -53,7 +53,7 @@ class WidgetXMLSniff implements Sniff
             if (!property_exists($element->attributes(), 'type')) {
                 continue;
             }
-            $type = $element['type'];
+            $type = (string) $element['type'];
             if (preg_match('/\//', $type)) {
                 $phpcsFile->addError(
                     "Factory name detected: {$type}.",

--- a/Magento2/Sniffs/Legacy/_files/restricted_classes.php
+++ b/Magento2/Sniffs/Legacy/_files/restricted_classes.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 /**
  * Classes that are restricted to use directly.

--- a/Magento2/Sniffs/Less/AvoidIdSniff.php
+++ b/Magento2/Sniffs/Less/AvoidIdSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/BracesFormattingSniff.php
+++ b/Magento2/Sniffs/Less/BracesFormattingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/ClassNamingSniff.php
+++ b/Magento2/Sniffs/Less/ClassNamingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/ColonSpacingSniff.php
+++ b/Magento2/Sniffs/Less/ColonSpacingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/ColourDefinitionSniff.php
+++ b/Magento2/Sniffs/Less/ColourDefinitionSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/CombinatorIndentationSniff.php
+++ b/Magento2/Sniffs/Less/CombinatorIndentationSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/CommentLevelsSniff.php
+++ b/Magento2/Sniffs/Less/CommentLevelsSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/Less/ImportantPropertySniff.php
+++ b/Magento2/Sniffs/Less/ImportantPropertySniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/IndentationSniff.php
+++ b/Magento2/Sniffs/Less/IndentationSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/PropertiesLineBreakSniff.php
+++ b/Magento2/Sniffs/Less/PropertiesLineBreakSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/PropertiesSortingSniff.php
+++ b/Magento2/Sniffs/Less/PropertiesSortingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/QuotesSniff.php
+++ b/Magento2/Sniffs/Less/QuotesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/SelectorDelimiterSniff.php
+++ b/Magento2/Sniffs/Less/SelectorDelimiterSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/SemicolonSpacingSniff.php
+++ b/Magento2/Sniffs/Less/SemicolonSpacingSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/TokenizerSymbolsInterface.php
+++ b/Magento2/Sniffs/Less/TokenizerSymbolsInterface.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 /**

--- a/Magento2/Sniffs/Less/TypeSelectorConcatenationSniff.php
+++ b/Magento2/Sniffs/Less/TypeSelectorConcatenationSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/TypeSelectorsSniff.php
+++ b/Magento2/Sniffs/Less/TypeSelectorsSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/VariablesSniff.php
+++ b/Magento2/Sniffs/Less/VariablesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Less/ZeroUnitsSniff.php
+++ b/Magento2/Sniffs/Less/ZeroUnitsSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Less;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
+++ b/Magento2/Sniffs/Methods/DeprecatedModelMethodSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Methods;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Namespaces/ImportsFromTestNamespaceSniff.php
+++ b/Magento2/Sniffs/Namespaces/ImportsFromTestNamespaceSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Namespaces;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/NamingConvention/InterfaceNameSniff.php
+++ b/Magento2/Sniffs/NamingConvention/InterfaceNameSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\NamingConvention;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/NamingConvention/ReservedWordsSniff.php
+++ b/Magento2/Sniffs/NamingConvention/ReservedWordsSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\NamingConvention;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/FinalImplementationSniff.php
+++ b/Magento2/Sniffs/PHP/FinalImplementationSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/GotoSniff.php
+++ b/Magento2/Sniffs/PHP/GotoSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/LiteralNamespacesSniff.php
+++ b/Magento2/Sniffs/PHP/LiteralNamespacesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/ReturnValueCheckSniff.php
+++ b/Magento2/Sniffs/PHP/ReturnValueCheckSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/ShortEchoSyntaxSniff.php
+++ b/Magento2/Sniffs/PHP/ShortEchoSyntaxSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/PHP/VarSniff.php
+++ b/Magento2/Sniffs/PHP/VarSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\PHP;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Performance/ForeachArrayMergeSniff.php
+++ b/Magento2/Sniffs/Performance/ForeachArrayMergeSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Performance;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/SQL/RawQuerySniff.php
+++ b/Magento2/Sniffs/SQL/RawQuerySniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\SQL;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Security/IncludeFileSniff.php
+++ b/Magento2/Sniffs/Security/IncludeFileSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Security;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Security/InsecureFunctionSniff.php
+++ b/Magento2/Sniffs/Security/InsecureFunctionSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Security;
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;

--- a/Magento2/Sniffs/Security/LanguageConstructSniff.php
+++ b/Magento2/Sniffs/Security/LanguageConstructSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Security;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Security/SuperglobalSniff.php
+++ b/Magento2/Sniffs/Security/SuperglobalSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Security;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Security/XssTemplateSniff.php
+++ b/Magento2/Sniffs/Security/XssTemplateSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Security;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Strings/ExecutableRegExSniff.php
+++ b/Magento2/Sniffs/Strings/ExecutableRegExSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Strings;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Strings/StringConcatSniff.php
+++ b/Magento2/Sniffs/Strings/StringConcatSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Strings;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Templates/ThisInTemplateSniff.php
+++ b/Magento2/Sniffs/Templates/ThisInTemplateSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Templates;
 
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/Magento2/Sniffs/Translation/ConstantUsageSniff.php
+++ b/Magento2/Sniffs/Translation/ConstantUsageSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Translation;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
+++ b/Magento2/Sniffs/Whitespace/MultipleEmptyLinesSniff.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento2\Sniffs\Whitespace;
 
 use PHP_CodeSniffer\Files\File;

--- a/Magento2/Tests/Eslint/AbstractEslintTestCase.php
+++ b/Magento2/Tests/Eslint/AbstractEslintTestCase.php
@@ -24,7 +24,7 @@ abstract class AbstractEslintTestCase extends TestCase
      */
     protected function assertFileContainsError(string $testFile, array $expectedMessages): void
     {
-        // phpcs:disable
+        // phpcs:ignore Magento2.Security.InsecureFunction.FoundWithAlternative
         exec(
             'npm run eslint -- Magento2/Tests/Eslint/' . $testFile,
             $output

--- a/Magento2/Tests/Eslint/AbstractEslintTestCase.php
+++ b/Magento2/Tests/Eslint/AbstractEslintTestCase.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento2\Tests\Eslint;
 
+use PHP_CodeSniffer\Config;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,6 +25,10 @@ abstract class AbstractEslintTestCase extends TestCase
      */
     protected function assertFileContainsError(string $testFile, array $expectedMessages): void
     {
+        if (Config::getExecutablePath('npm') === null) {
+            $this->markTestSkipped('npm is not installed here');
+        }
+
         // phpcs:ignore Magento2.Security.InsecureFunction.FoundWithAlternative
         exec(
             'npm run eslint -- Magento2/Tests/Eslint/' . $testFile,

--- a/Magento2/ruleset.xml
+++ b/Magento2/ruleset.xml
@@ -471,6 +471,10 @@
         <severity>7</severity>
         <type>warning</type>
     </rule>
+    <rule ref="Generic.PHP.RequireStrictTypes">
+        <severity>7</severity>
+        <type>warning</type>
+    </rule>
 
     <!-- Severity 6 warnings: Code style issues. -->
     <rule ref="Generic.ControlStructures.InlineControlStructure">


### PR DESCRIPTION
Fixes #33

The current `composer.json` file requires version 3.6.1 or better of PHP_CodeSniffer. That version and versions up to 3.7.2 only check that there is a declaration, but not if the declaration is setting the feature on/off. From version 3.8.0 onwards, the sniff also asserts that the feature is enabled. While this is a useful feature, I'm undecided if the minimum version for PHP_CodeSniffer should be increased as part of this pull request.