### PR TITLE
Small cleanup, removed duplicated keys from array

### DIFF
--- a/Magento2/Sniffs/Security/InsecureFunctionSniff.php
+++ b/Magento2/Sniffs/Security/InsecureFunctionSniff.php
@@ -25,7 +25,6 @@ class InsecureFunctionSniff extends ForbiddenFunctionsSniff
         'passthru' => null,
         'pcntl_exec' => null,
         'popen' => null,
-        'proc_open' => null,
         'serialize' => '\Magento\Framework\Serialize\SerializerInterface::serialize',
         'shell_exec' => null,
         'system' => null,


### PR DESCRIPTION
`'proc_open' => null,` is already defined in the same array on line 38, it makes no sense to keep both around.

Found with phpstan (while running it from inside magento core codebase):
```
$ ./vendor/bin/phpstan analyse --level=0 -c dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon vendor/magento | grep 'duplicate'
 3325/3325 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

  28     Array has 2 duplicate keys with value 'proc_open' ('proc_open', 'proc_open').
```
